### PR TITLE
Override the default content root path/current directory to use AppContext.BaseDirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ The following Legrand and BTicino products are partially or fully supported by O
 | In One by Legrand |                    | 88205             |                   |                                   |
 | In One by Legrand |                    | 88213             |                   |                                   |
 |                   |                    |                   |                   |                                   |
+| MyHome Up         |                    | 03535             | MH202             |                                   |
+| MyHome Up         |                    | 03598             | F454              |                                   |
+| MyHome Up         |                    | 03651             | F418U2            |                                   |
 | MyHome Up         |                    | 03847             | F411U1            |                                   |
 | MyHome Up         |                    | 03848             | F411U2            | Shutter mode is not yet supported |
-| MyHome Up         |                    | 03651             | F418U2            |                                   |
-| MyHome Up         |                    | 03598             | F454              |                                   |
-| MyHome Up         |                    | 03535             | MH202             |                                   |
 |                   |                    |                   |                   |                                   |
 | MyHome Play       | Céliane            | 67223             |                   |                                   |
 | MyHome Play       |                    | 88328             | 3578              |                                   |

--- a/src/OpenNetty.Daemon/Program.cs
+++ b/src/OpenNetty.Daemon/Program.cs
@@ -8,7 +8,13 @@ using System.Reactive.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-var builder = Host.CreateApplicationBuilder();
+Directory.SetCurrentDirectory(AppContext.BaseDirectory);
+
+var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+{
+    Args = args,
+    ContentRootPath = AppContext.BaseDirectory
+});
 
 builder.Services.AddSystemd()
     .AddWindowsService();


### PR DESCRIPTION
By default, both the .NET Generic Host and the file-based API use the current working directory as the default base folder. Since the OpenNetty configuration file/certificates are added in the same folder as the daemon executable, it makes more sense to use `AppContext.BaseDirectory`.