### PR TITLE
Set "on_command_type" to "brightness" for dimmable light endpoints

### DIFF
--- a/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
@@ -448,6 +448,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                         {
                             component["brightness_command_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.Brightness}/set";
                             component["brightness_scale"] = 100;
+                            component["on_command_type"] = "brightness";
                         }
 
                         if (endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) ||


### PR DESCRIPTION
Changing the brightness level always switches on a light endpoint, so a separate `/switch_state/set` command isn't necessary and can have a negative effect for Nitoo endpoints, as an `ON` bus command always sets the brightness to 100%, overriding the value previously configured. This PR fixes that by adding an `on_command_type` node with the value `brightness` for all the dimmable light endpoints.