### PR TITLE
Do not use the special "None" value to represent the "no derogation" case

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,10 +44,6 @@ jobs:
           os_name: windows
 
     steps:
-    - name: Select Xcode version
-      if: ${{ runner.os == 'macOS' }}
-      run: sudo xcode-select -s "/Applications/Xcode_15.4.app"
-
     - name: Checkout code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 

--- a/src/OpenNetty.Mqtt/OpenNettyMqttHostedService.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttHostedService.cs
@@ -200,7 +200,7 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
-                    var node = new JsonObject()
+                    var node = new JsonObject
                     {
                         ["scenario_type"] = "progressive",
                         ["duration"] = arguments.Duration.TotalSeconds
@@ -273,7 +273,7 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.SmartMeterIndexes, builder =>
                 {
-                    var node = new JsonObject()
+                    var node = new JsonObject
                     {
                         ["base_index"]        = arguments.Indexes.BaseIndex,
                         ["blue_index"]        = arguments.Indexes.BlueIndex,
@@ -341,7 +341,7 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
-                    var node = new JsonObject()
+                    var node = new JsonObject
                     {
                         ["scenario_type"] = "timed",
                         ["duration"] = arguments.Duration.TotalSeconds

--- a/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
@@ -457,7 +457,6 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
             };
 
             await foreach (var (endpoint, name) in from endpoint in endpoints
-                                                   where endpoint.GetBooleanSetting(OpenNettySettings.MqttDiscovery) is not false
                                                    let name = options.EndpointNameProvider(endpoint)
                                                    where !string.IsNullOrEmpty(name)
                                                    orderby name
@@ -596,7 +595,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                         ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.PilotWireDerogationMode}",
                         ["options"] = new JsonArray(
                         [
-                            "None",
+                            "No derogation",
                             "Comfort, until the next setpoint change",
                             "Comfort, for at least 4 hours",
                             "Comfort, for at least 8 hours",
@@ -615,7 +614,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                         ]),
                         ["value_template"] = """
                             {% set map = {
-                              'none': 'None',
+                              'none': 'No derogation',
                               'comfort': 'Comfort, until the next setpoint change',
                               'comfort:4h': 'Comfort, for at least 4 hours',
                               'comfort:8h': 'Comfort, for at least 8 hours',
@@ -636,7 +635,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                             """,
                         ["command_template"] = """
                             {% set map = {
-                              'None': 'none',
+                              'No derogation': 'none',
                               'Comfort, until the next setpoint change': 'comfort',
                               'Comfort, for at least 4 hours': 'comfort:4h',
                               'Comfort, for at least 8 hours': 'comfort:8h',

--- a/src/OpenNetty/OpenNettyController.cs
+++ b/src/OpenNetty/OpenNettyController.cs
@@ -1187,9 +1187,9 @@ public class OpenNettyController
         }
 
         var description = await GetUnitDescriptionAsync(endpoint, cancellationToken);
-        if (description is not { FunctionCode: 6, Values: [{ Length: > 0 }] values })
+        if (description is not { FunctionCode: 6 or 132, Values: [{ Length: > 0 }] values })
         {
-            throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
+            throw new InvalidOperationException(SR.GetResourceString(SR.ID0075));
         }
 
         return OpenNettyModels.TemperatureControl.PilotWireConfiguration.CreateFromUnitDescription(values);
@@ -1399,7 +1399,7 @@ public class OpenNettyController
         var description = await GetUnitDescriptionAsync(endpoint, cancellationToken);
         if (description is not { FunctionCode: 7, Values: [{ Length: > 0 }] values })
         {
-            throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
+            throw new InvalidOperationException(SR.GetResourceString(SR.ID0075));
         }
 
         return OpenNettyModels.TemperatureControl.SmartMeterInformation.CreateFromUnitDescription(values);
@@ -1565,7 +1565,7 @@ public class OpenNettyController
         var description = await GetUnitDescriptionAsync(endpoint, cancellationToken);
         if (description is not { FunctionCode: 133, Values: [{ Length: > 0 }] values })
         {
-            throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
+            throw new InvalidOperationException(SR.GetResourceString(SR.ID0075));
         }
 
         return values[0] switch

--- a/src/OpenNetty/OpenNettyCoordinator.cs
+++ b/src/OpenNetty/OpenNettyCoordinator.cs
@@ -941,7 +941,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Type     : OpenNettyMessageType.DimensionRead,
                                          Address  : OpenNettyAddress address,
                                          Dimension: OpenNettyDimension dimension,
-                                         Values   : ["6", { Length: > 0 } value] })
+                                         Values   : ["6" or "132", { Length: > 0 } value] })
                     when dimension == OpenNettyDimensions.Diagnostics.UnitDescription:
                 {
                     // Ignore the message if the corresponding endpoint couldn't be resolved or if it
@@ -991,7 +991,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
 
                     if (endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
                     {
-                        tasks.Add(ReportDerogationAndSetpointModesAsync(endpoint, CancellationToken.None).AsTask());
+                        tasks.Add(ReportSetpointModeAsync(endpoint, CancellationToken.None).AsTask());
                     }
 
                     if (endpoint is { Unit.Definition.AssociatedUnitId: byte unit })
@@ -1003,7 +1003,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
 
                             if (endpoint is not null && endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
                             {
-                                await ReportDerogationAndSetpointModesAsync(endpoint, CancellationToken.None);
+                                await ReportSetpointModeAsync(endpoint, CancellationToken.None);
                             }
                         }));
                     }
@@ -1017,13 +1017,16 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                             .OfType<OpenNettyEndpoint>()
                             .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating));
 
-                        tasks.Add(Parallel.ForEachAsync(endpoints, ReportDerogationAndSetpointModesAsync));
+                        tasks.Add(Parallel.ForEachAsync(endpoints, ReportSetpointModeAsync));
                     }
 
                     await Task.WhenAll(tasks);
 
-                    async ValueTask ReportDerogationAndSetpointModesAsync(OpenNettyEndpoint endpoint, CancellationToken cancellationToken)
-                    {
+                    // Note: setting the setpoint mode may not have an immediate effect on the device (e.g if a
+                    // derogation mode was set with a minimal duration during which setpoint commands are ignored).
+                    //
+                    // As such, the derogation mode cannot be reported here, as it may still be active on the device.
+                    async ValueTask ReportSetpointModeAsync(OpenNettyEndpoint endpoint, CancellationToken cancellationToken) =>
                         await _events.PublishAsync(new PilotWireSetpointModeReportedEventArgs(endpoint, value switch
                         {
                             "0" => OpenNettyModels.TemperatureControl.PilotWireMode.Comfort,
@@ -1034,15 +1037,6 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
 
                             _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0075))
                         }), cancellationToken);
-
-                        // Note: setting the setpoint mode may not have an immediate effect on the device (e.g if a
-                        // derogation mode was set with a minimal duration during which setpoint commands are ignored).
-                        // As such, the derogation mode cannot be reported here, as it may still be active on the device.
-                        if (notification is OpenNettyNotifications.MessageSent)
-                        {
-                            await _events.PublishAsync(new PilotWireDerogationModeReportedEventArgs(endpoint, null, null), cancellationToken);
-                        }
-                    }
                     break;
                 }
 


### PR DESCRIPTION
The `None` value is special-cased and is used by HA to "reset" the state of "select" components: https://www.home-assistant.io/integrations/select.mqtt/#state_topic