### PR TITLE
Introduce massive improvements to MQTT discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,51 +38,51 @@ gateways and a higher-level MQTT integration that can be directly used with home
 
 The following Legrand and BTicino products are partially or fully supported by OpenNetty:
 
-| Product series    | Product collection | Legrand reference | BTicino reference | Remarks                           |
-|-------------------|--------------------|-------------------|-------------------|-----------------------------------|
-| In One by Legrand | Lexic              | 03600             |                   |                                   |
-| In One by Legrand | Lexic              | 03648             |                   |                                   |
-| In One by Legrand | Lexic              | 03809             |                   |                                   |
-| In One by Legrand |                    | 43214             |                   |                                   |
-| In One by Legrand | Céliane            | 67201             |                   |                                   |
-| In One by Legrand | Céliane            | 67202             |                   |                                   |
-| In One by Legrand | Céliane            | 67203             |                   |                                   |
-| In One by Legrand | Céliane            | 67204             |                   |                                   |
-| In One by Legrand | Céliane            | 67208             |                   |                                   |
-| In One by Legrand | Céliane            | 67210             |                   |                                   |
-| In One by Legrand | Céliane            | 67212             |                   |                                   |
-| In One by Legrand | Céliane            | 67214             |                   |                                   |
-| In One by Legrand | Céliane            | 67215             |                   |                                   |
-| In One by Legrand | Céliane            | 67220             |                   |                                   |
-| In One by Legrand | Céliane            | 67222             |                   |                                   |
-| In One by Legrand | Céliane            | 67280             |                   |                                   |
-| In One by Legrand | Céliane            | 67290             |                   |                                   |
-| In One by Legrand | Céliane            | 67445             |                   |                                   |
-| In One by Legrand | Céliane            | 67448             |                   |                                   |
-| In One by Legrand | Plexo              | 69510             |                   |                                   |
-| In One by Legrand | Sagane             | 84520             |                   |                                   |
-| In One by Legrand | Sagane             | 84522             |                   |                                   |
-| In One by Legrand | Sagane             | 84523             |                   |                                   |
-| In One by Legrand | Sagane             | 84524             |                   |                                   |
-| In One by Legrand | Sagane             | 84525             |                   |                                   |
-| In One by Legrand | Sagane             | 84529             |                   |                                   |
-| In One by Legrand | Sagane             | 84530             |                   |                                   |
-| In One by Legrand | Sagane             | 84531             |                   |                                   |
-| In One by Legrand | Sagane             | 84542             |                   |                                   |
-| In One by Legrand |                    | 88205             |                   |                                   |
-| In One by Legrand |                    | 88213             |                   |                                   |
-|                   |                    |                   |                   |                                   |
-| MyHome Up         |                    | 03535             | MH202             |                                   |
-| MyHome Up         |                    | 03598             | F454              |                                   |
-| MyHome Up         |                    | 03651             | F418U2            |                                   |
-| MyHome Up         |                    | 03847             | F411U1            |                                   |
-| MyHome Up         |                    | 03848             | F411U2            |                                   |
-| MyHome Up         | Céliane            | 67557             |                   |                                   |
-| MyHome Up         | Céliane            | 67561             |                   |                                   |
-|                   |                    |                   |                   |                                   |
-| MyHome Play       | Céliane            | 67223             |                   |                                   |
-| MyHome Play       |                    | 88328             | 3578              |                                   |
-| MyHome Play       |                    | 88337             |                   |                                   |
+| Product series    | Product collection | Legrand reference | BTicino reference | Description                            |
+|-------------------|--------------------|-------------------|-------------------|----------------------------------------|
+| In One by Legrand | Lexic              | 03600             |                   | 2-gang DIN rail switch                 |
+| In One by Legrand | Lexic              | 03648             |                   | SCS/Nitoo gateway                      |
+| In One by Legrand | Lexic              | 03809             |                   | DIN rail energy meter                  |
+| In One by Legrand |                    | 43214             |                   | Wireless burglar alarm                 |
+| In One by Legrand | Céliane            | 67201             |                   | 1-gang switch                          |
+| In One by Legrand | Céliane            | 67202             |                   | 2-gang switch                          |
+| In One by Legrand | Céliane            | 67203             |                   | 1-gang switch with indicator light     |
+| In One by Legrand | Céliane            | 67204             |                   | 2-gang switch with indicator light     |
+| In One by Legrand | Céliane            | 67208             |                   | Light control switch                   |
+| In One by Legrand | Céliane            | 67210             |                   | Dimmer switch                          |
+| In One by Legrand | Céliane            | 67212             |                   | Dimmer switch with indicator light     |
+| In One by Legrand | Céliane            | 67214             |                   | Dimmer switch with indicator light     |
+| In One by Legrand | Céliane            | 67215             |                   | Motion sensor switch                   |
+| In One by Legrand | Céliane            | 67220             |                   | Switched outlet                        |
+| In One by Legrand | Céliane            | 67222             |                   | Dimmable switched outlet               |
+| In One by Legrand | Céliane            | 67280             |                   | Multipurpose scenario switch           |
+| In One by Legrand | Céliane            | 67290             |                   | Multipurpose scenario switch           |
+| In One by Legrand | Céliane            | 67445             |                   | Pilot wire cable outlet                |
+| In One by Legrand | Céliane            | 67448             |                   | Pilot wire derogation command          |
+| In One by Legrand | Plexo              | 69510             |                   | 1-gang outdoor switch                  |
+| In One by Legrand | Sagane             | 84520             |                   | 2-gang switch                          |
+| In One by Legrand | Sagane             | 84522             |                   | Motion sensor switch                   |
+| In One by Legrand | Sagane             | 84523             |                   | Switched outlet                        |
+| In One by Legrand | Sagane             | 84524             |                   | Dimmable switched outlet               |
+| In One by Legrand | Sagane             | 84525             |                   | Multipurpose scenario switch           |
+| In One by Legrand | Sagane             | 84529             |                   | Pilot wire derogation command          |
+| In One by Legrand | Sagane             | 84530             |                   | Pilot wire cable outlet                |
+| In One by Legrand | Sagane             | 84531             |                   | 1-gang switch                          |
+| In One by Legrand | Sagane             | 84542             |                   | Multipurpose scenario switch           |
+| In One by Legrand |                    | 88205             |                   | Pocket scenario remote control         |
+| In One by Legrand |                    | 88213             |                   | PLC/USB gateway                        |
+|                   |                    |                   |                   |                                        |
+| MyHome Up         |                    | 03535             | MH202             | SCS scenario scheduler                 |
+| MyHome Up         |                    | 03598             | F454              | SCS/Ethernet gateway                   |
+| MyHome Up         |                    | 03651             | F418U2            | 2-gang DIN rail dimmer switch          |
+| MyHome Up         |                    | 03847             | F411U1            | 1-gang DIN rail switch                 |
+| MyHome Up         |                    | 03848             | F411U2            | 2-gang DIN rail switch                 |
+| MyHome Up         | Céliane            | 67557             |                   | 2-channel advanced automation actuator |
+| MyHome Up         | Céliane            | 67561             |                   | 2-channel lighting/automation actuator |
+|                   |                    |                   |                   |                                        |
+| MyHome Play       | Céliane            | 67223             |                   | Light control switch                   |
+| MyHome Play       |                    | 88328             | 3578              | Zigbee/USB gateway                     |
+| MyHome Play       |                    | 88337             |                   | Switched outlet                        |
 
 > [!NOTE]
 > Support for additional devices will be progressively added depending on the demand.

--- a/src/OpenNetty.Mqtt/OpenNettyMqttAttributes.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttAttributes.cs
@@ -12,19 +12,19 @@ namespace OpenNetty.Mqtt;
 public static class OpenNettyMqttAttributes
 {
     /// <summary>
-    /// Battery.
+    /// Battery alert.
     /// </summary>
-    public const string Battery = "battery";
+    public const string BatteryAlert = "battery_alert";
+
+    /// <summary>
+    /// Battery level.
+    /// </summary>
+    public const string BatteryLevel = "battery_level";
 
     /// <summary>
     /// Brightness.
     /// </summary>
     public const string Brightness = "brightness";
-
-    /// <summary>
-    /// Dimming step.
-    /// </summary>
-    public const string DimmingStep = "dimming_step";
 
     /// <summary>
     /// Pilot wire derogation mode.
@@ -67,6 +67,11 @@ public static class OpenNettyMqttAttributes
     public const string SmartMeterRateType = "smart_meter_rate_type";
 
     /// <summary>
+    /// Startup date.
+    /// </summary>
+    public const string StartupDate = "startup_date";
+
+    /// <summary>
     /// Switch state.
     /// </summary>
     public const string SwitchState = "switch_state";
@@ -85,4 +90,9 @@ public static class OpenNettyMqttAttributes
     /// Wireless burglar alarm state.
     /// </summary>
     public const string WirelessBurglarAlarmState = "wireless_burglar_alarm_state";
+
+    /// <summary>
+    /// Zigbee binding.
+    /// </summary>
+    public const string ZigbeeBinding = "zigbee_binding";
 }

--- a/src/OpenNetty.Mqtt/OpenNettyMqttBuilder.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttBuilder.cs
@@ -181,11 +181,11 @@ public sealed class OpenNettyMqttBuilder
 
         return Configure(options =>
         {
-            options.DisableDiscovery = (bool?) element.Attribute("DisableDiscovery") ?? false;
+            options.DisableHomeAssistantDiscovery = (bool?) element.Attribute("DisableHomeAssistantDiscovery") ?? false;
 
             var topics = (
                 RootTopic: (string?) element.Attribute("RootTopic"),
-                DiscoveryRootTopic: (string?) element.Attribute("DiscoveryRootTopic"));
+                DiscoveryRootTopic: (string?) element.Attribute("HomeAssistantDiscoveryRootTopic"));
 
             if (!string.IsNullOrEmpty(topics.RootTopic))
             {
@@ -194,7 +194,7 @@ public sealed class OpenNettyMqttBuilder
 
             if (!string.IsNullOrEmpty(topics.DiscoveryRootTopic))
             {
-                options.DiscoveryRootTopic = topics.DiscoveryRootTopic;
+                options.HomeAssistantDiscoveryRootTopic = topics.DiscoveryRootTopic;
             }
 
             options.ClientOptions = builder.Build();

--- a/src/OpenNetty.Mqtt/OpenNettyMqttConfiguration.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttConfiguration.cs
@@ -14,16 +14,33 @@ namespace OpenNetty.Mqtt;
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
 public sealed class OpenNettyMqttConfiguration : IPostConfigureOptions<OpenNettyMqttOptions>,
+    IValidateOptions<OpenNettyOptions>,
     IValidateOptions<OpenNettyMqttOptions>
 {
+    /// <inheritdoc/>
+    public ValidateOptionsResult Validate(string? name, OpenNettyOptions options)
+    {
+        foreach (var endpoint in options.Endpoints)
+        {
+            if (endpoint.GetStringSetting(OpenNettySettings.MqttTopic) is string topic &&
+                (topic.Contains('+', StringComparison.OrdinalIgnoreCase) ||
+                 topic.Contains('*', StringComparison.OrdinalIgnoreCase)))
+            {
+                return ValidateOptionsResult.Fail(SR.FormatID2005(topic));
+            }
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+
     /// <inheritdoc/>
     public void PostConfigure(string? name, OpenNettyMqttOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        if (string.IsNullOrEmpty(options.DiscoveryRootTopic))
+        if (string.IsNullOrEmpty(options.HomeAssistantDiscoveryRootTopic))
         {
-            options.DiscoveryRootTopic = "homeassistant";
+            options.HomeAssistantDiscoveryRootTopic = "homeassistant";
         }
 
         if (string.IsNullOrEmpty(options.RootTopic))
@@ -41,6 +58,21 @@ public sealed class OpenNettyMqttConfiguration : IPostConfigureOptions<OpenNetty
             options.RootTopic.Contains('*', StringComparison.OrdinalIgnoreCase))
         {
             return ValidateOptionsResult.Fail(SR.GetResourceString(SR.ID2001));
+        }
+
+        if (options.RootTopic.EndsWith("/", StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidateOptionsResult.Fail(SR.GetResourceString(SR.ID2007));
+        }
+
+        if (options.HomeAssistantDiscoveryRootTopic.EndsWith("/", StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidateOptionsResult.Fail(SR.GetResourceString(SR.ID2008));
+        }
+
+        if (string.Equals(options.HomeAssistantDiscoveryRootTopic, options.RootTopic, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidateOptionsResult.Fail(SR.GetResourceString(SR.ID2009));
         }
 
         return ValidateOptionsResult.Success;

--- a/src/OpenNetty.Mqtt/OpenNettyMqttExtensions.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttExtensions.cs
@@ -37,8 +37,11 @@ public static class OpenNettyMqttExtensions
 
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IOpenNettyHandler, OpenNettyMqttHostedService>());
+
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IPostConfigureOptions<OpenNettyMqttOptions>, OpenNettyMqttConfiguration>());
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IValidateOptions<OpenNettyOptions>, OpenNettyMqttConfiguration>());
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IValidateOptions<OpenNettyMqttOptions>, OpenNettyMqttConfiguration>());
 

--- a/src/OpenNetty.Mqtt/OpenNettyMqttHostedService.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttHostedService.cs
@@ -65,14 +65,30 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
-                    builder.WithPayload("action");
+                    var node = new JsonObject
+                    {
+                        ["event_type"] = "action"
+                    };
+
+                    builder.WithContentType(MediaTypeNames.Application.Json);
+                    builder.WithPayload(node.ToJsonString());
+                }))
+                .Retry()
+                .SubscribeAsync(static arguments => ValueTask.CompletedTask),
+
+            await _events.BatteryAlertReported
+                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
+                .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.BatteryAlert, builder =>
+                {
+                    builder.WithPayload("ON");
+                    builder.WithRetainFlag();
                 }))
                 .Retry()
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.BatteryLevelReported
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
-                .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Battery, builder =>
+                .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.BatteryLevel, builder =>
                 {
                     builder.WithPayload(arguments.Level.ToString(CultureInfo.InvariantCulture));
                     builder.WithRetainFlag();
@@ -92,9 +108,16 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
 
             await _events.DimmingStepReported
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
-                .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.DimmingStep, builder =>
+                .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
-                    builder.WithPayload(arguments.Delta.ToString(CultureInfo.InvariantCulture));
+                    var node = new JsonObject
+                    {
+                        ["event_type"] = arguments.Delta is < 0 ? "dimming_step_down" : "dimming_step_up",
+                        ["delta"] = arguments.Delta
+                    };
+
+                    builder.WithContentType(MediaTypeNames.Application.Json);
+                    builder.WithPayload(node.ToJsonString());
                 }))
                 .Retry()
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
@@ -103,7 +126,13 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
-                    builder.WithPayload("OFF");
+                    var node = new JsonObject
+                    {
+                        ["event_type"] = "switch_off"
+                    };
+
+                    builder.WithContentType(MediaTypeNames.Application.Json);
+                    builder.WithPayload(node.ToJsonString());
                 }))
                 .Retry()
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
@@ -112,7 +141,13 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
-                    builder.WithPayload("ON");
+                    var node = new JsonObject
+                    {
+                        ["event_type"] = "switch_on"
+                    };
+
+                    builder.WithContentType(MediaTypeNames.Application.Json);
+                    builder.WithPayload(node.ToJsonString());
                 }))
                 .Retry()
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
@@ -202,7 +237,7 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 {
                     var node = new JsonObject
                     {
-                        ["scenario_type"] = "progressive",
+                        ["event_type"] = "progressive_action",
                         ["duration"] = arguments.Duration.TotalSeconds
                     };
 
@@ -216,7 +251,13 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
-                    builder.WithPayload("CLOSE");
+                    var node = new JsonObject
+                    {
+                        ["event_type"] = "shutter_down"
+                    };
+
+                    builder.WithContentType(MediaTypeNames.Application.Json);
+                    builder.WithPayload(node.ToJsonString());
                 }))
                 .Retry()
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
@@ -255,7 +296,13 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
-                    builder.WithPayload("STOP");
+                    var node = new JsonObject
+                    {
+                        ["event_type"] = "shutter_stop"
+                    };
+
+                    builder.WithContentType(MediaTypeNames.Application.Json);
+                    builder.WithPayload(node.ToJsonString());
                 }))
                 .Retry()
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
@@ -264,7 +311,13 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
-                    builder.WithPayload("OPEN");
+                    var node = new JsonObject
+                    {
+                        ["event_type"] = "shutter_up"
+                    };
+
+                    builder.WithContentType(MediaTypeNames.Application.Json);
+                    builder.WithPayload(node.ToJsonString());
                 }))
                 .Retry()
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
@@ -343,7 +396,7 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 {
                     var node = new JsonObject
                     {
-                        ["scenario_type"] = "timed",
+                        ["event_type"] = "timed_action",
                         ["duration"] = arguments.Duration.TotalSeconds
                     };
 
@@ -357,7 +410,22 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
-                    builder.WithPayload("toggle");
+                    var node = new JsonObject
+                    {
+                        ["event_type"] = "switch_toggle"
+                    };
+
+                    builder.WithContentType(MediaTypeNames.Application.Json);
+                    builder.WithPayload(node.ToJsonString());
+                }))
+                .Retry()
+                .SubscribeAsync(static arguments => ValueTask.CompletedTask),
+
+            await _events.UptimeReported
+                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
+                .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.StartupDate, builder =>
+                {
+                    builder.WithPayload((TimeProvider.System.GetUtcNow() - arguments.Duration).ToString("o", CultureInfo.InvariantCulture));
                 }))
                 .Retry()
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
@@ -421,38 +489,23 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
 
         async ValueTask ReportAsync(OpenNettyEndpoint endpoint, string attribute, Action<MqttApplicationMessageBuilder> configuration)
         {
-            var topic = GetMessageTopic(endpoint, attribute);
-            if (string.IsNullOrEmpty(topic))
-            {
-                return;
-            }
-
             var builder = new MqttApplicationMessageBuilder()
                 .WithPayloadFormatIndicator(MqttPayloadFormatIndicator.CharacterData)
                 .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.ExactlyOnce)
-                .WithTopic(topic);
+                .WithTopic(GetMessageTopic(endpoint, attribute));
 
             configuration(builder);
 
             await _client.EnqueueAsync(builder.Build());
         }
 
-        string? GetMessageTopic(OpenNettyEndpoint endpoint, string attribute)
-        {
-            var name = endpoint.GetStringSetting(OpenNettySettings.MqttEndpointName) ?? endpoint.Name?.ToLowerInvariant();
-            if (string.IsNullOrEmpty(name))
-            {
-                return null;
-            }
-
-            return new StringBuilder()
-                .Append(_options.CurrentValue.RootTopic)
-                .Append('/')
-                .Append(name)
-                .Append('/')
-                .Append(attribute)
-                .ToString();
-        }
+        string GetMessageTopic(OpenNettyEndpoint endpoint, string attribute) => new StringBuilder()
+            .Append(_options.CurrentValue.RootTopic)
+            .Append('/')
+            .Append(endpoint.GetStringSetting(OpenNettySettings.MqttTopic) ?? endpoint.Name.ToLowerInvariant())
+            .Append('/')
+            .Append(attribute)
+            .ToString();
     }
 
     /// <inheritdoc/>

--- a/src/OpenNetty.Mqtt/OpenNettyMqttOptions.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttOptions.cs
@@ -21,12 +21,12 @@ public sealed class OpenNettyMqttOptions
     /// <summary>
     /// Gets or sets a boolean indicating whether Home Assistant discovery is enabled.
     /// </summary>
-    public bool DisableDiscovery { get; set; }
+    public bool DisableHomeAssistantDiscovery { get; set; }
 
     /// <summary>
     /// Gets or sets the MQTT discovery root topic (by default, "homeassistant").
     /// </summary>
-    public string DiscoveryRootTopic { get; set; } = default!;
+    public string HomeAssistantDiscoveryRootTopic { get; set; } = default!;
 
     /// <summary>
     /// Gets or sets the MQTT root topic (by default, "opennetty").

--- a/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
@@ -4,7 +4,6 @@
  * the license and the contributors participating to this project.
  */
 
-using System;
 using System.Buffers.Text;
 using System.Globalization;
 using System.IO.Hashing;
@@ -13,7 +12,7 @@ using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
+using System.Runtime.InteropServices;
 using System.Text.Json.Nodes;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
@@ -105,7 +104,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 return AsyncObservable.Return((Message: message, Endpoint: endpoint, Attribute: attribute, Operation: operation.Value));
 
                 bool Matches(OpenNettyEndpoint endpoint) => string.Equals(
-                    endpoint.GetStringSetting(OpenNettySettings.MqttEndpointName) ?? endpoint.Name?.ToLowerInvariant(),
+                    endpoint.GetStringSetting(OpenNettySettings.MqttTopic) ?? endpoint.Name.ToLowerInvariant(),
                     name, StringComparison.Ordinal);
             })
             .GroupBy(static arguments => arguments.Endpoint.Name)
@@ -117,8 +116,23 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
 
                     try
                     {
-                        switch (attribute.ToLowerInvariant())
+                        switch (attribute)
                         {
+                            case OpenNettyMqttAttributes.BatteryAlert when operation is OpenNettyMqttOperation.Set:
+                                switch (message.ConvertPayloadToString()?.ToLowerInvariant())
+                                {
+                                    case "off":
+                                        await client.EnqueueAsync(new MqttApplicationMessageBuilder()
+                                            .WithPayloadFormatIndicator(MqttPayloadFormatIndicator.CharacterData)
+                                            .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.ExactlyOnce)
+                                            .WithTopic(message.Topic[..^4])
+                                            .WithPayload("OFF")
+                                            .WithRetainFlag()
+                                            .Build());
+                                        break;
+                                }
+                                break;
+
                             case OpenNettyMqttAttributes.Brightness when operation is OpenNettyMqttOperation.Get:
                                 _ = await _controller.EnumerateBrightnessAsync(endpoint).ToListAsync();
                                 break;
@@ -269,28 +283,32 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                             case OpenNettyMqttAttributes.Scenario when operation is OpenNettyMqttOperation.Set:
                                 switch (message.ConvertPayloadToString()?.ToLowerInvariant())
                                 {
-                                    case "action" when endpoint.HasCapability(OpenNettyCapabilities.BasicScenario):
-                                        await _controller.DispatchBasicScenarioAsync(endpoint);
+                                    case "action":
+                                        await _controller.DispatchActionScenarioAsync(endpoint);
                                         break;
 
-                                    case "down" when endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenario):
+                                    case "shutter_down":
                                         await _controller.DispatchShutterDownScenarioAsync(endpoint);
                                         break;
 
-                                    case "on" when endpoint.HasCapability(OpenNettyCapabilities.OnOffScenario):
-                                        await _controller.DispatchOnScenarioAsync(endpoint);
-                                        break;
-
-                                    case "off" when endpoint.HasCapability(OpenNettyCapabilities.OnOffScenario):
-                                        await _controller.DispatchOffScenarioAsync(endpoint);
-                                        break;
-
-                                    case "stop" when endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenario):
+                                    case "shutter_stop":
                                         await _controller.DispatchShutterStopScenarioAsync(endpoint);
                                         break;
 
-                                    case "up" when endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenario):
+                                    case "shutter_up":
                                         await _controller.DispatchShutterUpScenarioAsync(endpoint);
+                                        break;
+
+                                    case "stop_action":
+                                        await _controller.DispatchStopActionScenarioAsync(endpoint);
+                                        break;
+
+                                    case "switch_on":
+                                        await _controller.DispatchOnScenarioAsync(endpoint);
+                                        break;
+
+                                    case "switch_off":
+                                        await _controller.DispatchOffScenarioAsync(endpoint);
                                         break;
                                 }
                                 break;
@@ -338,6 +356,10 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                                 _ = await _controller.GetSmartMeterInformationAsync(endpoint);
                                 break;
 
+                            case OpenNettyMqttAttributes.StartupDate when operation is OpenNettyMqttOperation.Get:
+                                _ = await _controller.GetUptimeAsync(endpoint);
+                                break;
+
                             case OpenNettyMqttAttributes.SwitchState when operation is OpenNettyMqttOperation.Get:
                                 _ = await _controller.EnumerateSwitchStatesAsync(endpoint).ToListAsync();
                                 break;
@@ -382,6 +404,19 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                             case OpenNettyMqttAttributes.WaterHeaterState when operation is OpenNettyMqttOperation.Get:
                                 _ = await _controller.GetWaterHeaterStateAsync(endpoint);
                                 break;
+
+                            case OpenNettyMqttAttributes.ZigbeeBinding when operation is OpenNettyMqttOperation.Set:
+                                switch (message.ConvertPayloadToString()?.ToLowerInvariant())
+                                {
+                                    case "bind":
+                                        await _controller.BindAsync(endpoint);
+                                        break;
+
+                                    case "unbind":
+                                        await _controller.UnbindAsync(endpoint);
+                                        break;
+                                }
+                                break;
                         }
 
                         if (!string.IsNullOrEmpty(message.ResponseTopic))
@@ -420,31 +455,22 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
     /// <inheritdoc/>
     public async Task AnnounceEndpointsAsync(IManagedMqttClient client, CancellationToken cancellationToken)
     {
-        if (_options.CurrentValue is not { DisableDiscovery: false } options)
+        if (_options.CurrentValue is not { DisableHomeAssistantDiscovery: false } options)
         {
             return;
         }
 
-        await foreach (var endpoints in from endpoint in _manager.EnumerateEndpointsAsync(cancellationToken)
-                                        where endpoint.GetBooleanSetting(OpenNettySettings.MqttDiscovery) is not false
-                                        where endpoint.Device is { SerialNumber.Length: > 0 }
-                                        group endpoint by endpoint.Device!)
+        await foreach (var device in _manager.EnumerateDevicesAsync(cancellationToken))
         {
-            var components = new JsonObject();
-
-            var device = new JsonObject
+            if (device.GetBooleanSetting(OpenNettySettings.HomeAssistantDiscovery) is false ||
+                device.SerialNumber is null or { Length: 0 })
             {
-                ["identifiers"] = new JsonArray([endpoints.Key.SerialNumber]),
-                ["manufacturer"] = Enum.GetName(endpoints.Key.Identity.Brand),
-                ["model"] = endpoints.Key.Identity.Model,
-                ["serial_number"] = endpoints.Key.SerialNumber,
-                ["name"] = $"{Enum.GetName(endpoints.Key.Identity.Brand)} {endpoints.Key.Identity.Model} ({endpoints.Key.SerialNumber})"
-            };
-
-            if (endpoints.Key.GetStringSetting(OpenNettySettings.HomeAssistantSuggestedArea) is { Length: > 0 } area)
-            {
-                device["suggested_area"] = area;
+                continue;
             }
+
+            var identifier = ComputeDeviceUniqueId(device);
+
+            var components = new JsonObject();
 
             var configuration = new JsonObject
             {
@@ -456,17 +482,17 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                        ?.InformationalVersion,
                     ["support_url"] = "https://github.com/opennetty/opennetty-core"
                 },
-                ["device"] = device,
+                ["device"] = CreateDeviceNode(device, identifier),
                 ["components"] = components,
                 ["qos"] = 2
             };
 
-            await foreach (var (endpoint, name) in from endpoint in endpoints
-                                                   let name = endpoint.GetStringSetting(OpenNettySettings.MqttEndpointName) ?? endpoint.Name?.ToLowerInvariant()
-                                                   where !string.IsNullOrEmpty(name)
-                                                   orderby name
-                                                   select (Endpoint: endpoint, Name: name))
+            await foreach (var endpoint in from endpoint in _manager.EnumerateEndpointsAsync(cancellationToken)
+                                           where endpoint.Device == device
+                                           select endpoint)
             {
+                var topic = endpoint.GetStringSetting(OpenNettySettings.MqttTopic) ?? endpoint.Name.ToLowerInvariant();
+
                 if (SupportsLightOrSwitchEntity(endpoint))
                 {
                     // Note: by default, endpoints that support ON/OFF switching are always treated as light entities.
@@ -476,22 +502,34 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     var component = new JsonObject
                     {
                         ["platform"] = platform,
-                        ["unique_id"] = ComputeUniqueId("feb44223-4814-4652-933c-53dbbaabac3f"u8),
-                        ["name"] = endpoint.Name,
-                        ["command_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.SwitchState}/set"
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "feb44223-4814-4652-933c-53dbbaabac3f"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : platform is OpenNettySettings.HomeAssistantEntityTypes.Switch ? "Switch" : "Light",
+                            endpoint: endpoint,
+                            setting : OpenNettySettings.HomeAssistantLightSwitchName,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(SupportsLightOrSwitchEntity)
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SwitchState}/set"
                     };
+
+                    if (endpoint.GetStringSetting(OpenNettySettings.HomeAssistantLightSwitchIcon) is string icon)
+                    {
+                        component["icon"] = icon;
+                    }
 
                     // Note: endpoints that can't report their state (e.g radio Nitoo devices) can still be mapped to a light entity:
                     // in that case, Home Assistant will automatically use the optimistic mode to dynamically update the current state.
                     if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
                     {
-                        component["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.SwitchState}";
+                        component["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SwitchState}";
                     }
 
                     // Unlike light entities, switch entities can specify a device class but cannot support brightness control.
                     if (platform is OpenNettySettings.HomeAssistantEntityTypes.Switch)
                     {
-                        component["device_class"] = endpoint.GetStringSetting(OpenNettySettings.HomeAssistantDeviceClass)
+                        component["device_class"] = endpoint.GetStringSetting(OpenNettySettings.HomeAssistantLightSwitchDeviceClass)
                             ?? OpenNettySettings.HomeAssistantDeviceClasses.Switch;
                     }
 
@@ -500,7 +538,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                         if (endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingControl) ||
                             endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingControl))
                         {
-                            component["brightness_command_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.Brightness}/set";
+                            component["brightness_command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.Brightness}/set";
                             component["brightness_scale"] = 100;
                             component["on_command_type"] = "brightness";
                         }
@@ -508,11 +546,401 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                         if (endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) ||
                             endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState))
                         {
-                            component["brightness_state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.Brightness}";
+                            component["brightness_state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.Brightness}";
                         }
                     }
 
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", component);
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
+                    {
+                        components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                        {
+                            ["platform"] = "button",
+                            ["unique_id"] = ComputeEntityUniqueId(endpoint, "3a10d925-c599-41a9-8a7e-30a04aefec86"u8),
+                            ["name"] = ComputeEntityName(
+                                name    : "Get switch state",
+                                endpoint: endpoint,
+                                setting : OpenNettySettings.HomeAssistantLightSwitchName,
+                                count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                    .Where(endpoint => endpoint.Device == device)
+                                    .Where(SupportsLightOrSwitchEntity)
+                                    .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
+                                    .CountAsync(cancellationToken)),
+                            ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SwitchState}/get",
+                            ["payload_press"] = string.Empty
+                        });
+                    }
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) ||
+                        endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState))
+                    {
+                        components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                        {
+                            ["platform"] = "button",
+                            ["unique_id"] = ComputeEntityUniqueId(endpoint, "f05ecfb8-70d5-4116-b0a8-2f6d9d02090f"u8),
+                            ["name"] = ComputeEntityName(
+                                name    : "Get brightness",
+                                endpoint: endpoint,
+                                setting : OpenNettySettings.HomeAssistantLightSwitchName,
+                                count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                    .Where(endpoint => endpoint.Device == device)
+                                    .Where(SupportsLightOrSwitchEntity)
+                                    .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) ||
+                                                       endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState))
+                                    .CountAsync(cancellationToken)),
+                            ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.Brightness}/get",
+                            ["payload_press"] = string.Empty
+                        });
+                    }
+                }
+
+                if (SupportsCoverEntity(endpoint))
+                {
+                    var component = new JsonObject
+                    {
+                        ["platform"] = "cover",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "9b138d62-bb0d-49cb-8624-1d85f9e86a6e"u8),
+                        ["device_class"] = endpoint.GetStringSetting(OpenNettySettings.HomeAssistantCoverDeviceClass)
+                            ?? OpenNettySettings.HomeAssistantDeviceClasses.Shutter,
+                        ["name"] = ComputeEntityName(
+                            name    : "Cover",
+                            endpoint: endpoint,
+                            setting : OpenNettySettings.HomeAssistantCoverName,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(SupportsCoverEntity)
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ShutterState}/set"
+                    };
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.BasicShutterState))
+                    {
+                        component["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ShutterState}";
+                    }
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.AdvancedShutterControl))
+                    {
+                        component["set_position_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ShutterPosition}/set";
+                    }
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.AdvancedShutterState))
+                    {
+                        component["position_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ShutterPosition}";
+                    }
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", component);
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.BasicShutterState) ||
+                        endpoint.HasCapability(OpenNettyCapabilities.AdvancedShutterState))
+                    {
+                        components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                        {
+                            ["platform"] = "button",
+                            ["unique_id"] = ComputeEntityUniqueId(endpoint, "3a760f9d-ca89-4c9e-9ad4-8ba40ad36f59"u8),
+                            ["name"] = ComputeEntityName(
+                                name    : "Get cover state",
+                                endpoint: endpoint,
+                                setting : OpenNettySettings.HomeAssistantCoverName,
+                                count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                    .Where(endpoint => endpoint.Device == device)
+                                    .Where(SupportsCoverEntity)
+                                    .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.BasicShutterState) ||
+                                                       endpoint.HasCapability(OpenNettyCapabilities.AdvancedShutterState))
+                                    .CountAsync(cancellationToken)),
+                            ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ShutterState}/get",
+                            ["payload_press"] = string.Empty
+                        });
+                    }
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.AdvancedShutterState))
+                    {
+                        components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                        {
+                            ["platform"] = "button",
+                            ["unique_id"] = ComputeEntityUniqueId(endpoint, "5731274c-e498-4c7b-8671-6de8c448eb99"u8),
+                            ["name"] = ComputeEntityName(
+                                name    : "Get cover position",
+                                endpoint: endpoint,
+                                setting : OpenNettySettings.HomeAssistantCoverName,
+                                count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                    .Where(endpoint => endpoint.Device == device)
+                                    .Where(SupportsCoverEntity)
+                                    .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.AdvancedShutterState))
+                                    .CountAsync(cancellationToken)),
+                            ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ShutterPosition}/get",
+                            ["payload_press"] = string.Empty
+                        });
+                    }
+                }
+
+                if (endpoint.HasCapability(OpenNettyCapabilities.ActionScenarioState) ||
+                    endpoint.HasCapability(OpenNettyCapabilities.DimmingScenarioState) ||
+                    endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioState) ||
+                    endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenarioState) ||
+                    endpoint.HasCapability(OpenNettyCapabilities.StopActionScenarioState) ||
+                    endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioState) ||
+                    endpoint.HasCapability(OpenNettyCapabilities.TimedScenarioState) ||
+                    endpoint.HasCapability(OpenNettyCapabilities.ToggleScenarioState))
+                {
+                    var types = new HashSet<string>(StringComparer.Ordinal);
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.ActionScenarioState))
+                    {
+                        types.Add("action");
+                    }
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.DimmingScenarioState))
+                    {
+                        types.Add("dimming_step_up");
+                        types.Add("dimming_step_down");
+                    }
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioState))
+                    {
+                        types.Add("switch_on");
+                        types.Add("switch_off");
+                    }
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenarioState))
+                    {
+                        types.Add("progressive_action");
+                    }
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.StopActionScenarioState))
+                    {
+                        types.Add("stop_action");
+                    }
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioState))
+                    {
+                        types.Add("shutter_up");
+                        types.Add("shutter_down");
+                        types.Add("shutter_stop");
+                    }
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.TimedScenarioState))
+                    {
+                        types.Add("timed_action");
+                    }
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.ToggleScenarioState))
+                    {
+                        types.Add("switch_toggle");
+                    }
+
+                    var component = new JsonObject
+                    {
+                        ["platform"] = "event",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "7faeaa9a-ae51-43f4-af82-65d2e24e14d0"u8),
+                        ["icon"] = endpoint.GetStringSetting(OpenNettySettings.HomeAssistantScenarioIcon) ?? "mdi:lightning-bolt",
+                        ["name"] = ComputeEntityName(
+                            name    : "Scenario",
+                            endpoint: endpoint,
+                            setting : OpenNettySettings.HomeAssistantScenarioName,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.ActionScenarioState) ||
+                                                   endpoint.HasCapability(OpenNettyCapabilities.DimmingScenarioState) ||
+                                                   endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioState) ||
+                                                   endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenarioState) ||
+                                                   endpoint.HasCapability(OpenNettyCapabilities.StopActionScenarioState) ||
+                                                   endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioState) ||
+                                                   endpoint.HasCapability(OpenNettyCapabilities.TimedScenarioState) ||
+                                                   endpoint.HasCapability(OpenNettyCapabilities.ToggleScenarioState))
+                                .CountAsync(cancellationToken)),
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.Scenario}",
+                        ["event_types"] = new JsonArray([.. types])
+                    };
+
+                    if (endpoint.GetStringSetting(OpenNettySettings.HomeAssistantScenarioDeviceClass) is string type)
+                    {
+                        component["device_class"] = type;
+                    }
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", component);
+                }
+
+                if (endpoint.HasCapability(OpenNettyCapabilities.ActionScenarioControl))
+                {
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "63485e4c-a3bd-4fc9-831d-b96bacddade9"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Dispatch action scenario",
+                            endpoint: endpoint,
+                            setting : OpenNettySettings.HomeAssistantScenarioName,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.ActionScenarioControl))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.Scenario}/set",
+                        ["payload_press"] = "action"
+                    });
+                }
+
+                if (endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioControl))
+                {
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "f053a594-66fa-42a6-9237-64d570b2bd57"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Dispatch ON scenario",
+                            endpoint: endpoint,
+                            setting : OpenNettySettings.HomeAssistantScenarioName,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioControl))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.Scenario}/set",
+                        ["payload_press"] = "switch_on"
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "d292636e-00d3-442e-b1db-73d60b4085ec"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Dispatch OFF scenario",
+                            endpoint: endpoint,
+                            setting : OpenNettySettings.HomeAssistantScenarioName,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioControl))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.Scenario}/set",
+                        ["payload_press"] = "switch_off"
+                    });
+                }
+
+                if (endpoint.HasCapability(OpenNettyCapabilities.StopActionScenarioControl))
+                {
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "bca953c0-7598-4baa-91df-f14ddc30450f"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Dispatch stop action scenario",
+                            endpoint: endpoint,
+                            setting : OpenNettySettings.HomeAssistantScenarioName,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.StopActionScenarioControl))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.Scenario}/set",
+                        ["payload_press"] = "stop_action",
+                        ["enabled_by_default"] = false
+                    });
+                }
+
+                if (endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioControl))
+                {
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "9065ccb4-d2c6-47f5-b118-e3d2ecbe20c3"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Dispatch UP scenario",
+                            endpoint: endpoint,
+                            setting : OpenNettySettings.HomeAssistantScenarioName,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioControl))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.Scenario}/set",
+                        ["payload_press"] = "shutter_up"
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "4006cf9e-620c-49d4-81b3-ab060d376966"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Dispatch DOWN scenario",
+                            endpoint: endpoint,
+                            setting : OpenNettySettings.HomeAssistantScenarioName,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioControl))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.Scenario}/set",
+                        ["payload_press"] = "shutter_down"
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "d13fdcd2-c974-490a-b544-436a91785ffa"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Dispatch STOP scenario",
+                            endpoint: endpoint,
+                            setting : OpenNettySettings.HomeAssistantScenarioName,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioControl))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.Scenario}/set",
+                        ["payload_press"] = "shutter_stop"
+                    });
+                }
+
+                if (endpoint.HasCapability(OpenNettyCapabilities.BatteryAlert))
+                {
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "binary_sensor",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "b7dd3824-ddc3-4cf3-b79e-168faa710e43"u8),
+                        ["device_class"] = "battery",
+                        ["off_delay"] = 3600,
+                        ["name"] = ComputeEntityName(
+                            name    : "Battery",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.BatteryAlert))
+                                .CountAsync(cancellationToken)),
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.BatteryAlert}"
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "7f7625f0-2461-4804-9cae-829a1040cd93"u8),
+                        ["icon"] = "mdi:battery-check",
+                        ["name"] = ComputeEntityName(
+                            name    : "Reset battery state",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.BatteryAlert))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.BatteryAlert}/set",
+                        ["payload_press"] = "OFF"
+                    });
+                }
+
+                if (endpoint.HasCapability(OpenNettyCapabilities.BatteryLevel))
+                {
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "sensor",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "6a8c7f1c-426a-47ab-97a1-a476acc603fd"u8),
+                        ["device_class"] = "battery",
+                        ["unit_of_measurement"] = "%",
+                        ["name"] = ComputeEntityName(
+                            name    : "Battery",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.BatteryLevel))
+                                .CountAsync(cancellationToken)),
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.BatteryLevel}"
+                    });
                 }
 
                 if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchControl) &&
@@ -522,52 +950,18 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
                     {
                         ["platform"] = "button",
-                        ["unique_id"] = ComputeUniqueId("5c207503-bbc7-47dc-a4a7-8833c5bf058f"u8),
-                        ["name"] = endpoint.Name,
-                        ["command_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.SwitchState}/set",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "5c207503-bbc7-47dc-a4a7-8833c5bf058f"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Push button",
+                            endpoint: endpoint,
+                            setting : OpenNettySettings.HomeAssistantLightSwitchName,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchControl))
+                                .Where(endpoint => endpoint.GetStringSetting(OpenNettySettings.SwitchMode) is OpenNettySettings.SwitchModes.PushButton)
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SwitchState}/set",
                         ["payload_press"] = "ON"
-                    });
-                }
-
-                if (SupportsCoverEntity(endpoint))
-                {
-                    var component = new JsonObject
-                    {
-                        ["platform"] = "cover",
-                        ["unique_id"] = ComputeUniqueId("9b138d62-bb0d-49cb-8624-1d85f9e86a6e"u8),
-                        ["device_class"] = endpoint.GetStringSetting(OpenNettySettings.HomeAssistantDeviceClass)
-                            ?? OpenNettySettings.HomeAssistantDeviceClasses.Shutter,
-                        ["name"] = endpoint.Name,
-                        ["command_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.ShutterState}/set"
-                    };
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.BasicShutterState))
-                    {
-                        component["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.ShutterState}";
-                    }
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.AdvancedShutterControl))
-                    {
-                        component["set_position_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.ShutterPosition}/set";
-                    }
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.AdvancedShutterState))
-                    {
-                        component["position_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.ShutterPosition}";
-                    }
-
-                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", component);
-                }
-
-                if (endpoint.HasCapability(OpenNettyCapabilities.Battery))
-                {
-                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
-                    {
-                        ["platform"] = "sensor",
-                        ["unique_id"] = ComputeUniqueId("6a8c7f1c-426a-47ab-97a1-a476acc603fd"u8),
-                        ["device_class"] = "battery",
-                        ["name"] = "Battery level",
-                        ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.Battery}"
                     });
                 }
 
@@ -576,11 +970,18 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
                     {
                         ["platform"] = "select",
-                        ["unique_id"] = ComputeUniqueId("205a01a1-ba4c-4e9b-a19a-c1589c445cbb"u8),
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "205a01a1-ba4c-4e9b-a19a-c1589c445cbb"u8),
                         ["icon"] = "mdi:radiator",
-                        ["name"] = "Setpoint mode",
-                        ["command_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.PilotWireSetpointMode}/set",
-                        ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.PilotWireSetpointMode}",
+                        ["name"] = ComputeEntityName(
+                            name    : "Setpoint mode",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.PilotWireSetpointMode}/set",
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.PilotWireSetpointMode}",
                         ["options"] = new JsonArray(["Comfort", "Comfort -1°C", "Comfort -2°C", "Eco", "Frost protection"]),
                         ["value_template"] = """
                             {% set map = {
@@ -607,11 +1008,18 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
                     {
                         ["platform"] = "select",
-                        ["unique_id"] = ComputeUniqueId("f5f57920-d758-4ca8-8161-2614d4abeef0"u8),
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "f5f57920-d758-4ca8-8161-2614d4abeef0"u8),
                         ["icon"] = "mdi:radiator",
-                        ["name"] = "Derogation mode",
-                        ["command_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.PilotWireDerogationMode}/set",
-                        ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.PilotWireDerogationMode}",
+                        ["name"] = ComputeEntityName(
+                            name    : "Derogation mode",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.PilotWireDerogationMode}/set",
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.PilotWireDerogationMode}",
                         ["options"] = new JsonArray(
                         [
                             "No derogation",
@@ -674,6 +1082,38 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                             {{ map[value] }}
                             """
                     });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "7a9130b9-675a-437d-b806-cbfe6f6e20a6"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Get setpoint mode",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.PilotWireSetpointMode}/get",
+                        ["payload_press"] = string.Empty
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "787582e8-0c5f-4c97-9277-0ad23dab4024"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Get derogation mode",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.PilotWireDerogationMode}/get",
+                        ["payload_press"] = string.Empty
+                    });
                 }
 
                 if (endpoint.HasCapability(OpenNettyCapabilities.SmartMeterIndexes))
@@ -681,66 +1121,113 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
                     {
                         ["platform"] = "sensor",
-                        ["unique_id"] = ComputeUniqueId("6c83787a-3537-49fa-b409-dc15d5c37b43"u8),
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "6c83787a-3537-49fa-b409-dc15d5c37b43"u8),
                         ["device_class"] = "energy",
                         ["unit_of_measurement"] = "kWh",
-                        ["name"] = "Base index",
-                        ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.SmartMeterIndexes}",
+                        ["suggested_display_precision"] = 0,
+                        ["name"] = ComputeEntityName(
+                            name    : "Base index",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.SmartMeterIndexes))
+                                .CountAsync(cancellationToken)),
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SmartMeterIndexes}",
                         ["value_template"] = "{{ value_json.base_index }}"
                     });
 
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
                     {
                         ["platform"] = "sensor",
-                        ["unique_id"] = ComputeUniqueId("0a9d909b-8449-496e-b38c-4dc3e2653288"u8),
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "0a9d909b-8449-496e-b38c-4dc3e2653288"u8),
                         ["device_class"] = "energy",
                         ["unit_of_measurement"] = "kWh",
-                        ["name"] = "Blue index",
-                        ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.SmartMeterIndexes}",
+                        ["suggested_display_precision"] = 0,
+                        ["name"] = ComputeEntityName(
+                            name    : "Blue index",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.SmartMeterIndexes))
+                                .CountAsync(cancellationToken)),
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SmartMeterIndexes}",
                         ["value_template"] = "{{ value_json.blue_index }}"
                     });
 
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
                     {
                         ["platform"] = "sensor",
-                        ["unique_id"] = ComputeUniqueId("2661d8db-085a-41bb-bab6-a1627cbf91d0"u8),
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "2661d8db-085a-41bb-bab6-a1627cbf91d0"u8),
                         ["device_class"] = "energy",
                         ["unit_of_measurement"] = "kWh",
-                        ["name"] = "Off-peak index",
-                        ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.SmartMeterIndexes}",
+                        ["suggested_display_precision"] = 0,
+                        ["name"] = ComputeEntityName(
+                            name    : "Off-peak index",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.SmartMeterIndexes))
+                                .CountAsync(cancellationToken)),
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SmartMeterIndexes}",
                         ["value_template"] = "{{ value_json.off_peak_index }}"
                     });
 
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
                     {
                         ["platform"] = "sensor",
-                        ["unique_id"] = ComputeUniqueId("7dcf846c-fbdd-4457-9a17-9cbc0a7c072b"u8),
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "7dcf846c-fbdd-4457-9a17-9cbc0a7c072b"u8),
                         ["device_class"] = "energy",
                         ["unit_of_measurement"] = "kWh",
-                        ["name"] = "Red index",
-                        ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.SmartMeterIndexes}",
+                        ["suggested_display_precision"] = 0,
+                        ["name"] = ComputeEntityName(
+                            name    : "Red index",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.SmartMeterIndexes))
+                                .CountAsync(cancellationToken)),
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SmartMeterIndexes}",
                         ["value_template"] = "{{ value_json.red_index }}"
                     });
 
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
                     {
                         ["platform"] = "sensor",
-                        ["unique_id"] = ComputeUniqueId("1de29bc5-70b6-4302-aa27-8ecbcce13ec9"u8),
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "1de29bc5-70b6-4302-aa27-8ecbcce13ec9"u8),
                         ["device_class"] = "energy",
                         ["unit_of_measurement"] = "kWh",
-                        ["name"] = "White index",
-                        ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.SmartMeterIndexes}",
+                        ["suggested_display_precision"] = 0,
+                        ["name"] = ComputeEntityName(
+                            name    : "White index",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.SmartMeterIndexes))
+                                .CountAsync(cancellationToken)),
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SmartMeterIndexes}",
                         ["value_template"] = "{{ value_json.white_index }}"
                     });
 
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
                     {
                         ["platform"] = "sensor",
-                        ["unique_id"] = ComputeUniqueId("e07f0687-6ca1-47d9-a5b7-b20c0e79775a"u8),
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "e07f0687-6ca1-47d9-a5b7-b20c0e79775a"u8),
                         ["device_class"] = "enum",
                         ["icon"] = "mdi:receipt-text-outline",
-                        ["name"] = "Subscription type",
-                        ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.SmartMeterIndexes}",
+                        ["name"] = ComputeEntityName(
+                            name    : "Subscription type",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.SmartMeterIndexes))
+                                .CountAsync(cancellationToken)),
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SmartMeterIndexes}",
                         ["options"] = new JsonArray(
                         [
                             "Base",
@@ -756,6 +1243,22 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                             {{ map[value_json.subscription_type] }}
                             """,
                     });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "2eddee8f-7c81-47ea-a775-785e9dfb5c26"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Get indexes",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.SmartMeterIndexes))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SmartMeterIndexes}/get",
+                        ["payload_press"] = string.Empty
+                    });
                 }
 
                 if (endpoint.HasCapability(OpenNettyCapabilities.SmartMeterInformation))
@@ -763,11 +1266,18 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
                     {
                         ["platform"] = "sensor",
-                        ["unique_id"] = ComputeUniqueId("31eda1f3-343f-4cd7-9f56-ea792fcaec7f"u8),
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "31eda1f3-343f-4cd7-9f56-ea792fcaec7f"u8),
                         ["device_class"] = "enum",
                         ["icon"] = "mdi:receipt-text-outline",
-                        ["name"] = "Rate type",
-                        ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.SmartMeterRateType}",
+                        ["name"] = ComputeEntityName(
+                            name    : "Rate type",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.SmartMeterInformation))
+                                .CountAsync(cancellationToken)),
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SmartMeterRateType}",
                         ["options"] = new JsonArray(
                         [
                             "Off-peak",
@@ -778,19 +1288,93 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                               'off_peak': 'Off-peak',
                               'peak': 'Peak'
                             } %}
-                            {{ map[value_json.rate_type] }}
+                            {{ map[value] }}
                             """,
                     });
 
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
                     {
                         ["platform"] = "binary_sensor",
-                        ["unique_id"] = ComputeUniqueId("280fd1d1-4220-42ec-bf70-69936b728eb2"u8),
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "280fd1d1-4220-42ec-bf70-69936b728eb2"u8),
                         ["icon"] = "mdi:transmission-tower-off",
-                        ["name"] = "Power cut mode active",
-                        ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.SmartMeterPowerCutMode}",
+                        ["name"] = ComputeEntityName(
+                            name    : "Power cut mode active",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.SmartMeterInformation))
+                                .CountAsync(cancellationToken)),
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SmartMeterPowerCutMode}",
                         ["payload_on"] = "1",
                         ["payload_off"] = "0"
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "91e32508-61fa-46e3-ba57-32166b2de116"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Get rate type",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.SmartMeterInformation))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SmartMeterRateType}/get",
+                        ["payload_press"] = string.Empty
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "df24321d-01e8-4d1a-9cca-92ece18934b4"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Get power cut mode",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.SmartMeterInformation))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.SmartMeterPowerCutMode}/get",
+                        ["payload_press"] = string.Empty
+                    });
+                }
+
+                if (endpoint.HasCapability(OpenNettyCapabilities.Uptime))
+                {
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "sensor",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "46c1f892-f9bf-46b6-8658-fed1d7eb177b"u8),
+                        ["device_class"] = "date",
+                        ["name"] = ComputeEntityName(
+                            name    : "Startup date",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.Uptime))
+                                .CountAsync(cancellationToken)),
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.StartupDate}",
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "5e9b5094-b028-492c-8be4-5b73139e2c57"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Get startup date",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.Uptime))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.StartupDate}/get",
+                        ["payload_press"] = string.Empty
                     });
                 }
 
@@ -799,11 +1383,18 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
                     {
                         ["platform"] = "select",
-                        ["unique_id"] = ComputeUniqueId("733d9bf6-fd89-4ce1-bd71-d12a1c6a846e"u8),
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "733d9bf6-fd89-4ce1-bd71-d12a1c6a846e"u8),
                         ["icon"] = "mdi:water-boiler",
-                        ["name"] = "Setpoint mode",
-                        ["command_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.WaterHeaterSetpointMode}/set",
-                        ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.WaterHeaterSetpointMode}",
+                        ["name"] = ComputeEntityName(
+                            name    : "Setpoint mode",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.WaterHeating))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.WaterHeaterSetpointMode}/set",
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.WaterHeaterSetpointMode}",
                         ["options"] = new JsonArray(["Automatic", "Forced on", "Forced off"]),
                         ["value_template"] = """
                             {% set map = {
@@ -826,12 +1417,51 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
                     {
                         ["platform"] = "binary_sensor",
-                        ["unique_id"] = ComputeUniqueId("344b6548-196d-42de-b627-22530cc28f07"u8),
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "344b6548-196d-42de-b627-22530cc28f07"u8),
                         ["icon"] = "mdi:fire",
-                        ["name"] = "Heater active",
-                        ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.WaterHeaterState}",
+                        ["name"] = ComputeEntityName(
+                            name    : "Heater active",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.WaterHeating))
+                                .CountAsync(cancellationToken)),
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.WaterHeaterState}",
                         ["payload_on"] = "heating",
                         ["payload_off"] = "idle"
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "9aa4633b-c253-4623-a80c-54ba9d681777"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Get setpoint mode",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.WaterHeating))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.WaterHeaterSetpointMode}/get",
+                        ["payload_press"] = string.Empty
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "bb186d7c-f49d-4aa2-8770-a0fdcf9de123"u8),
+                        ["name"] = ComputeEntityName(
+                            name    : "Get heater state",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.WaterHeating))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.WaterHeaterState}/get",
+                        ["payload_press"] = string.Empty
                     });
                 }
 
@@ -840,11 +1470,18 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
                     {
                         ["platform"] = "sensor",
-                        ["unique_id"] = ComputeUniqueId("2dd476d5-a35a-442a-a3f2-4c2621dcf375"u8),
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "2dd476d5-a35a-442a-a3f2-4c2621dcf375"u8),
                         ["device_class"] = "enum",
                         ["icon"] = "mdi:shield-home-outline",
-                        ["name"] = "Alarm state",
-                        ["state_topic"] = $"{options.RootTopic}/{name}/{OpenNettyMqttAttributes.WirelessBurglarAlarmState}",
+                        ["name"] = ComputeEntityName(
+                            name    : "Alarm state",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.WirelessBurglarAlarmState))
+                                .CountAsync(cancellationToken)),
+                        ["state_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.WirelessBurglarAlarmState}",
                         ["options"] = new JsonArray(
                         [
                             "Disarmed",
@@ -868,28 +1505,156 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     });
                 }
 
-                string ComputeUniqueId(ReadOnlySpan<byte> identifier) => Base64Url.EncodeToString(XxHash128.Hash(
-                [
-                    ..identifier,
-                    ..Encoding.UTF8.GetBytes(name),
-                    ..Encoding.UTF8.GetBytes(endpoint.Address?.Value ?? string.Empty)
-                ]));
+                if (endpoint.HasCapability(OpenNettyCapabilities.ZigbeeBinding))
+                {
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "d04dc07d-b614-4e3e-aeac-ccaead40d919"u8),
+                        ["icon"] = "mdi:link",
+                        ["name"] = ComputeEntityName(
+                            name    : "Bind to gateway",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.ZigbeeBinding))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ZigbeeBinding}/set",
+                        ["payload_press"] = "bind"
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "55a25c45-cb7a-4b74-baa4-7f9b87465d1a"u8),
+                        ["icon"] = "mdi:link-off",
+                        ["name"] = ComputeEntityName(
+                            name    : "Unbind from gateway",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.ZigbeeBinding))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ZigbeeBinding}/set",
+                        ["payload_press"] = "unbind"
+                    });
+                }
             }
 
             if (components.Count is not 0)
             {
-                var node = $"opennetty-{Enum.GetName(endpoints.Key.Definition.Protocol)!.ToLowerInvariant()}";
-                var topic = $"{options.DiscoveryRootTopic}/device/{node}/{endpoints.Key.SerialNumber}/config";
-
                 await client.EnqueueAsync(new MqttApplicationMessageBuilder()
                     .WithContentType(MediaTypeNames.Application.Json)
                     .WithPayload(configuration.ToJsonString())
                     .WithPayloadFormatIndicator(MqttPayloadFormatIndicator.CharacterData)
                     .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.ExactlyOnce)
                     .WithRetainFlag()
-                    .WithTopic(topic)
+                    .WithTopic($"{options.HomeAssistantDiscoveryRootTopic}/device/opennetty/{identifier}/config")
                     .Build());
             }
+        }
+
+        static JsonObject CreateDeviceNode(OpenNettyDevice device, string identifier)
+        {
+            var node = new JsonObject
+            {
+                ["identifiers"] = new JsonArray([identifier]),
+                ["manufacturer"] = Enum.GetName(device.Identity.Brand),
+                ["model"] = device.Identity.Description,
+                ["model_id"] = device.Identity.Model,
+                ["serial_number"] = device.SerialNumber,
+                ["name"] = $"{Enum.GetName(device.Identity.Brand)} {device.Identity.Model} ({device.SerialNumber})"
+            };
+
+            if (device.GetStringSetting(OpenNettySettings.HomeAssistantSuggestedArea) is { Length: > 0 } area)
+            {
+                node["suggested_area"] = area;
+            }
+
+            return node;
+        }
+
+        static string ComputeDeviceUniqueId(OpenNettyDevice device)
+        {
+            var hash = new XxHash128();
+            hash.Append(MemoryMarshal.AsBytes<char>(Enum.GetName(device.Definition.Protocol)));
+            hash.Append(MemoryMarshal.AsBytes<char>(device.SerialNumber));
+
+            return Base64Url.EncodeToString(hash.GetCurrentHash());
+        }
+
+        static string ComputeEntityUniqueId(OpenNettyEndpoint endpoint, ReadOnlySpan<byte> discriminator)
+        {
+            var hash = new XxHash128();
+            hash.Append(MemoryMarshal.AsBytes<char>(endpoint.Name));
+            hash.Append(discriminator);
+
+            return Base64Url.EncodeToString(hash.GetCurrentHash());
+        }
+
+        static string ComputeEntityName(string name, OpenNettyEndpoint endpoint, OpenNettySetting? setting, int count)
+        {
+            if (count is < 2)
+            {
+                return name;
+            }
+
+            if (setting is not null && endpoint.GetStringSetting(setting.Value) is { Length: > 0 } description)
+            {
+                return $"{name} [{description}]";
+            }
+
+            if (endpoint.Address is OpenNettyAddress address)
+            {
+                return $"{name} [{address.Type switch
+                {
+                    OpenNettyAddressType.ZigbeeAllDevicesAllUnits => "D=all/U=all",
+
+                    OpenNettyAddressType.ZigbeeAllDevicesSpecificUnit
+                        when OpenNettyAddress.ToZigbeeAddress(address) is { Unit: byte unit }
+                        => $"D=all/U={unit.ToString(CultureInfo.InvariantCulture)}",
+
+                    OpenNettyAddressType.ZigbeeSpecificDeviceAllUnits
+                        when OpenNettyAddress.ToZigbeeAddress(address) is { Identifier: uint identifier }
+                        => $"D={identifier.ToString(CultureInfo.InvariantCulture)}/U=all",
+
+                    OpenNettyAddressType.ZigbeeSpecificDeviceSpecificUnit
+                        when OpenNettyAddress.ToZigbeeAddress(address) is { Identifier: uint identifier, Unit: byte unit }
+                        => $"D={identifier.ToString(CultureInfo.InvariantCulture)}/U={unit.ToString(CultureInfo.InvariantCulture)}",
+
+                    OpenNettyAddressType.NitooDevice
+                        when OpenNettyAddress.ToNitooAddress(address) is { Identifier: uint identifier }
+                        => $"D={identifier.ToString(CultureInfo.InvariantCulture)}",
+
+                    OpenNettyAddressType.NitooUnit
+                        when OpenNettyAddress.ToNitooAddress(address) is { Identifier: uint identifier, Unit: byte unit }
+                        => $"D={identifier.ToString(CultureInfo.InvariantCulture)}/U={unit.ToString(CultureInfo.InvariantCulture)}",
+
+                    OpenNettyAddressType.ScsLightPointArea
+                        when OpenNettyAddress.ToScsLightPointAreaAddress(address) is { Extension: byte extension, Area: byte area }
+                        => $"A={area.ToString(CultureInfo.InvariantCulture)}/I={extension.ToString(CultureInfo.InvariantCulture)}",
+
+                    OpenNettyAddressType.ScsLightPointGeneral
+                        when OpenNettyAddress.ToScsLightPointGeneralAddress(address) is byte extension
+                        => $"GEN/I={extension.ToString(CultureInfo.InvariantCulture)}",
+
+                    OpenNettyAddressType.ScsLightPointGroup
+                        when OpenNettyAddress.ToScsLightPointGroupAddress(address)
+                        is { Extension: byte extension, Group: byte group }
+                        => $"GR={group.ToString(CultureInfo.InvariantCulture)}/I={extension.ToString(CultureInfo.InvariantCulture)}",
+
+                    OpenNettyAddressType.ScsLightPointPointToPoint
+                        when OpenNettyAddress.ToScsLightPointPointToPointAddress(address)
+                        is { Extension: byte extension, Area: byte area, Point: byte point }
+                        => $"PL={point.ToString(CultureInfo.InvariantCulture)}/A={area.ToString(CultureInfo.InvariantCulture)}/I={extension.ToString(CultureInfo.InvariantCulture)}",
+
+                    _ => string.Empty
+                }}]";
+            }
+
+            return $"{name} [Local gateway]";
         }
 
         static bool SupportsCoverEntity(OpenNettyEndpoint endpoint)

--- a/src/OpenNetty/OpenNettyAddress.cs
+++ b/src/OpenNetty/OpenNettyAddress.cs
@@ -444,32 +444,6 @@ public readonly struct OpenNettyAddress : IEquatable<OpenNettyAddress>
     }
 
     /// <summary>
-    /// Determines whether the specified address is a Nitoo address.
-    /// </summary>
-    /// <param name="address">The address.</param>
-    /// <returns><see langword="true"/> if the address is a Nitoo address, <see langword="false"/> otherwise.</returns>
-    public static bool IsNitooAddress(OpenNettyAddress address)
-        => address.Type is OpenNettyAddressType.NitooDevice or OpenNettyAddressType.NitooUnit;
-
-    /// <summary>
-    /// Determines whether the specified address is a SCS address.
-    /// </summary>
-    /// <param name="address">The address.</param>
-    /// <returns><see langword="true"/> if the address is a SCS address, <see langword="false"/> otherwise.</returns>
-    public static bool IsScsAddress(OpenNettyAddress address)
-        => address.Type is OpenNettyAddressType.ScsLightPointArea  or OpenNettyAddressType.ScsLightPointGeneral or
-                           OpenNettyAddressType.ScsLightPointGroup or OpenNettyAddressType.ScsLightPointPointToPoint;
-
-    /// <summary>
-    /// Determines whether the specified address is a Zigbee address.
-    /// </summary>
-    /// <param name="address">The address.</param>
-    /// <returns><see langword="true"/> if the address is a Zigbee address, <see langword="false"/> otherwise.</returns>
-    public static bool IsZigbeeAddress(OpenNettyAddress address)
-        => address.Type is OpenNettyAddressType.ZigbeeAllDevicesAllUnits     or OpenNettyAddressType.ZigbeeAllDevicesSpecificUnit or
-                           OpenNettyAddressType.ZigbeeSpecificDeviceAllUnits or OpenNettyAddressType.ZigbeeSpecificDeviceSpecificUnit;
-
-    /// <summary>
     /// Converts the specified address to a Nitoo address.
     /// </summary>
     /// <param name="address">The address.</param>
@@ -477,7 +451,7 @@ public readonly struct OpenNettyAddress : IEquatable<OpenNettyAddress>
     /// <exception cref="InvalidOperationException">The address doesn't represent a valid Nitoo address.</exception>
     public static (uint Identifier, byte Unit) ToNitooAddress(OpenNettyAddress address)
     {
-        if (!IsNitooAddress(address))
+        if (address.Type is not (OpenNettyAddressType.NitooDevice or OpenNettyAddressType.NitooUnit))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0052), nameof(address));
         }
@@ -496,7 +470,7 @@ public readonly struct OpenNettyAddress : IEquatable<OpenNettyAddress>
     /// <param name="address">The address.</param>
     /// <returns>A SCS light point area address based on the specified address.</returns>
     /// <exception cref="ArgumentException">The address doesn't represent a valid SCS light point area address.</exception>
-    public static (byte? Extension, byte? Area) ToScsLightPointAreaAddress(OpenNettyAddress address)
+    public static (byte Extension, byte Area) ToScsLightPointAreaAddress(OpenNettyAddress address)
     {
         if (address.Type is not OpenNettyAddressType.ScsLightPointArea)
         {
@@ -511,7 +485,7 @@ public readonly struct OpenNettyAddress : IEquatable<OpenNettyAddress>
         return address.Parameters switch
         {
             { IsDefaultOrEmpty: true } when byte.TryParse(address.Value, CultureInfo.InvariantCulture, out byte area) && area is >= 0 and <= 10
-                => (Extension: null, Area: area),
+                => (Extension: 0, Area: area),
 
             ["4", string value] when
                 byte.TryParse(address.Value, CultureInfo.InvariantCulture, out byte area) &&
@@ -557,7 +531,7 @@ public readonly struct OpenNettyAddress : IEquatable<OpenNettyAddress>
     /// <param name="address">The address.</param>
     /// <returns>A SCS light point group address based on the specified address.</returns>
     /// <exception cref="ArgumentException">The address doesn't represent a valid SCS light point group address.</exception>
-    public static (byte? Extension, byte? Group) ToScsLightPointGroupAddress(OpenNettyAddress address)
+    public static (byte Extension, byte Group) ToScsLightPointGroupAddress(OpenNettyAddress address)
     {
         if (address.Type is not OpenNettyAddressType.ScsLightPointGroup)
         {
@@ -572,7 +546,7 @@ public readonly struct OpenNettyAddress : IEquatable<OpenNettyAddress>
         return address.Parameters switch
         {
             [string value] when byte.TryParse(value, CultureInfo.InvariantCulture, out byte group) && group is >= 1 and <= 255
-                => (Extension: null, Group: group),
+                => (Extension: 0, Group: group),
 
             [string first, "4", string third] when
                 byte.TryParse(first, CultureInfo.InvariantCulture, out byte group)     && group     is >= 1 and <= 255 &&
@@ -589,7 +563,7 @@ public readonly struct OpenNettyAddress : IEquatable<OpenNettyAddress>
     /// <param name="address">The address.</param>
     /// <returns>A SCS light point point-to-point address based on the specified address.</returns>
     /// <exception cref="ArgumentException">The address doesn't represent a valid SCS light point point-to-point address.</exception>
-    public static (byte? Extension, byte? Area, byte? Point) ToScsLightPointPointToPointAddress(OpenNettyAddress address)
+    public static (byte Extension, byte Area, byte Point) ToScsLightPointPointToPointAddress(OpenNettyAddress address)
     {
         if (address.Type is not OpenNettyAddressType.ScsLightPointPointToPoint)
         {
@@ -599,7 +573,7 @@ public readonly struct OpenNettyAddress : IEquatable<OpenNettyAddress>
         return address.Parameters switch
         {
             { IsDefaultOrEmpty: true } when GetAreaAndLightPoint(address.Value) is { Area: byte area, Point: byte point }
-                => (Extension: null, Area: area, Point: point),
+                => (Extension: 0, Area: area, Point: point),
 
             ["4", string value] when
                 GetAreaAndLightPoint(address.Value) is { Area: byte area, Point: byte point } &&
@@ -645,7 +619,9 @@ public readonly struct OpenNettyAddress : IEquatable<OpenNettyAddress>
     /// <exception cref="ArgumentException">The address doesn't represent a valid Zigbee address.</exception>
     public static (uint? Identifier, byte Unit) ToZigbeeAddress(OpenNettyAddress address)
     {
-        if (!IsZigbeeAddress(address))
+        if (address.Type is not
+            (OpenNettyAddressType.ZigbeeAllDevicesAllUnits     or OpenNettyAddressType.ZigbeeAllDevicesSpecificUnit or
+             OpenNettyAddressType.ZigbeeSpecificDeviceAllUnits or OpenNettyAddressType.ZigbeeSpecificDeviceSpecificUnit))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0062), nameof(address));
         }

--- a/src/OpenNetty/OpenNettyBuilder.cs
+++ b/src/OpenNetty/OpenNettyBuilder.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.IO.Ports;
 using System.Net;
+using System.Text;
 using System.Xml.Linq;
 using Microsoft.Extensions.FileProviders;
 
@@ -349,6 +350,23 @@ public sealed class OpenNettyBuilder
                 _ => throw new InvalidOperationException(SR.FormatID0088(name, "Type"))
             };
 
+            var protocol = type switch
+            {
+                null => device?.Definition.Protocol ?? throw new InvalidOperationException(SR.FormatID0088(name, "Type")),
+
+                OpenNettyAddressType.NitooDevice or OpenNettyAddressType.NitooUnit => OpenNettyProtocol.Nitoo,
+
+                OpenNettyAddressType.ScsLightPointArea  or OpenNettyAddressType.ScsLightPointGeneral or
+                OpenNettyAddressType.ScsLightPointGroup or OpenNettyAddressType.ScsLightPointPointToPoint
+                    => OpenNettyProtocol.Scs,
+
+                OpenNettyAddressType.ZigbeeAllDevicesAllUnits     or OpenNettyAddressType.ZigbeeAllDevicesSpecificUnit or
+                OpenNettyAddressType.ZigbeeSpecificDeviceAllUnits or OpenNettyAddressType.ZigbeeSpecificDeviceSpecificUnit
+                    => OpenNettyProtocol.Zigbee,
+
+                _ => throw new InvalidOperationException(SR.FormatID0088(name, "Type"))
+            };
+
             var address = type switch
             {
                 null => (OpenNettyAddress?) null,
@@ -392,25 +410,102 @@ public sealed class OpenNettyBuilder
                 _ => throw new InvalidOperationException(SR.FormatID0088(name, "Type"))
             };
 
-            var protocol = address is not null ?
-                (OpenNettyAddress.IsNitooAddress(address.Value)  ? OpenNettyProtocol.Nitoo  :
-                 OpenNettyAddress.IsScsAddress(address.Value)    ? OpenNettyProtocol.Scs    :
-                 OpenNettyAddress.IsZigbeeAddress(address.Value) ? OpenNettyProtocol.Zigbee :
-                 throw new InvalidOperationException(SR.FormatID0088(name, "Type"))) :
-                 device?.Definition.Protocol ?? throw new InvalidOperationException(SR.FormatID0088(name, "Type"));
-
             endpoints.Add(new OpenNettyEndpoint
             {
                 Address = address,
                 Capabilities = device is null && unit is null ? GetCapabilities(endpoint) : [],
+                Description = (string?) endpoint.Attribute("Description"),
                 Device = device,
                 Gateway = (string?) endpoint.Attribute("Gateway") is string gateway ? FindGatewayByName(gateways, gateway) : null,
                 Medium = device?.Definition.Medium,
-                Name = name,
+                Name = name ?? ComputeDefaultEndpointName(protocol, address, device, unit),
                 Protocol = protocol,
                 Settings = GetSettings(endpoint),
                 Unit = unit
             });
+
+            static string ComputeDefaultEndpointName(
+                OpenNettyProtocol protocol, OpenNettyAddress? address, OpenNettyDevice? device, OpenNettyUnit? unit)
+            {
+                var builder = new StringBuilder(Enum.GetName(protocol));
+                builder.Append('/');
+
+                switch (protocol)
+                {
+                    case OpenNettyProtocol.Nitoo or OpenNettyProtocol.Zigbee:
+                        if (string.IsNullOrEmpty(device?.SerialNumber))
+                        {
+                            throw new InvalidOperationException(SR.GetResourceString(SR.ID0118));
+                        }
+
+                        builder.Append(device.SerialNumber);
+
+                        if (unit is not null)
+                        {
+                            builder.Append('/');
+                            builder.Append(unit.Definition.Id);
+                        }
+                        break;
+
+                    case OpenNettyProtocol.Scs:
+                        if (address is null)
+                        {
+                            throw new InvalidOperationException(SR.GetResourceString(SR.ID0119));
+                        }
+
+                        switch (address.Value.Type)
+                        {
+                            case OpenNettyAddressType.ScsLightPointArea:
+                            {
+                                var (extension, area) = OpenNettyAddress.ToScsLightPointAreaAddress(address.Value);
+                                builder.Append("light-point-area");
+                                builder.Append('/');
+                                builder.Append(extension);
+                                builder.Append('/');
+                                builder.Append(area);
+                                break;
+                            }
+
+                            case OpenNettyAddressType.ScsLightPointGeneral:
+                            {
+                                var extension = OpenNettyAddress.ToScsLightPointGeneralAddress(address.Value);
+                                builder.Append("light-point-general");
+                                builder.Append('/');
+                                builder.Append(extension);
+                                break;
+                            }
+
+                            case OpenNettyAddressType.ScsLightPointGroup:
+                            {
+                                var (extension, group) = OpenNettyAddress.ToScsLightPointGroupAddress(address.Value);
+                                builder.Append("light-point-group");
+                                builder.Append('/');
+                                builder.Append(extension);
+                                builder.Append('/');
+                                builder.Append(group);
+                                break;
+                            }
+
+                            case OpenNettyAddressType.ScsLightPointPointToPoint:
+                            {
+                                var (extension, area, point) = OpenNettyAddress.ToScsLightPointPointToPointAddress(address.Value);
+                                builder.Append("light-point-point-to-point");
+                                builder.Append('/');
+                                builder.Append(extension);
+                                builder.Append('/');
+                                builder.Append(area);
+                                builder.Append('/');
+                                builder.Append(point);
+                                break;
+                            }
+                        }
+
+                        builder.Append(address.Value.ToString());
+                        break;
+                }
+
+                return builder.ToString();
+            }
         }
 
         return Configure(options =>

--- a/src/OpenNetty/OpenNettyCapabilities.cs
+++ b/src/OpenNetty/OpenNettyCapabilities.cs
@@ -12,6 +12,16 @@ namespace OpenNetty;
 public static class OpenNettyCapabilities
 {
     /// <summary>
+    /// Action scenario control.
+    /// </summary>
+    public static readonly OpenNettyCapability ActionScenarioControl = new("Action scenario control");
+
+    /// <summary>
+    /// Action scenario state.
+    /// </summary>
+    public static readonly OpenNettyCapability ActionScenarioState = new("Action scenario state");
+
+    /// <summary>
     /// Advanced dimming control.
     /// </summary>
     public static readonly OpenNettyCapability AdvancedDimmingControl = new("Advanced dimming control");
@@ -42,11 +52,6 @@ public static class OpenNettyCapabilities
     public static readonly OpenNettyCapability BasicDimmingState = new("Basic dimming state");
 
     /// <summary>
-    /// Basic scenario.
-    /// </summary>
-    public static readonly OpenNettyCapability BasicScenario = new("Basic scenario");
-
-    /// <summary>
     /// Basic shutter control.
     /// </summary>
     public static readonly OpenNettyCapability BasicShutterControl = new("Basic shutter control");
@@ -57,9 +62,14 @@ public static class OpenNettyCapabilities
     public static readonly OpenNettyCapability BasicShutterState = new("Basic shutter state");
 
     /// <summary>
-    /// Battery.
+    /// Battery alert.
     /// </summary>
-    public static readonly OpenNettyCapability Battery = new("Battery");
+    public static readonly OpenNettyCapability BatteryAlert = new("Battery alert");
+
+    /// <summary>
+    /// Battery level.
+    /// </summary>
+    public static readonly OpenNettyCapability BatteryLevel = new("Battery level");
 
     /// <summary>
     /// Date/time.
@@ -72,9 +82,24 @@ public static class OpenNettyCapabilities
     public static readonly OpenNettyCapability DeviceDescription = new("Device description");
 
     /// <summary>
-    /// Dimming scenario.
+    /// Dimming scenario control.
     /// </summary>
-    public static readonly OpenNettyCapability DimmingScenario = new("Dimming scenario");
+    public static readonly OpenNettyCapability DimmingScenarioControl = new("Dimming scenario control");
+
+    /// <summary>
+    /// Dimming scenario state.
+    /// </summary>
+    public static readonly OpenNettyCapability DimmingScenarioState = new("Dimming scenario state");
+
+    /// <summary>
+    /// Firmware version.
+    /// </summary>
+    public static readonly OpenNettyCapability FirmwareVersion = new("Firmware version");
+
+    /// <summary>
+    /// Firmware version.
+    /// </summary>
+    public static readonly OpenNettyCapability HardwareVersion = new("Hardware version");
 
     /// <summary>
     /// Memory reading.
@@ -87,9 +112,14 @@ public static class OpenNettyCapabilities
     public static readonly OpenNettyCapability MemoryWriting = new("Memory writing");
 
     /// <summary>
-    /// On/off scenario.
+    /// On/off scenario control.
     /// </summary>
-    public static readonly OpenNettyCapability OnOffScenario = new("On/off scenario");
+    public static readonly OpenNettyCapability OnOffScenarioControl = new("On/off scenario control");
+
+    /// <summary>
+    /// On/off scenario state.
+    /// </summary>
+    public static readonly OpenNettyCapability OnOffScenarioState = new("On/off scenario state");
 
     /// <summary>
     /// On/off switch control.
@@ -127,14 +157,14 @@ public static class OpenNettyCapabilities
     public static readonly OpenNettyCapability PilotWireHeating = new("Pilot wire heating");
 
     /// <summary>
-    /// Pilot wire scenario.
+    /// Progressive scenario control.
     /// </summary>
-    public static readonly OpenNettyCapability PilotWireScenario = new("Pilot wire scenario");
+    public static readonly OpenNettyCapability ProgressiveScenarioControl = new("Progressive scenario control");
 
     /// <summary>
-    /// Progressive scenario.
+    /// Progressive scenario state.
     /// </summary>
-    public static readonly OpenNettyCapability ProgressiveScenario = new("Progressive scenario");
+    public static readonly OpenNettyCapability ProgressiveScenarioState = new("Progressive scenario state");
 
     /// <summary>
     /// Smart meter indexes.
@@ -147,19 +177,39 @@ public static class OpenNettyCapabilities
     public static readonly OpenNettyCapability SmartMeterInformation = new("Smart meter information");
 
     /// <summary>
-    /// Stop/up/down scenario.
+    /// Action scenario control.
     /// </summary>
-    public static readonly OpenNettyCapability StopUpDownScenario = new("Stop/up/down scenario");
+    public static readonly OpenNettyCapability StopActionScenarioControl = new("Stop action scenario control");
 
     /// <summary>
-    /// Timed scenario.
+    /// Action scenario state.
     /// </summary>
-    public static readonly OpenNettyCapability TimedScenario = new("Timed scenario");
+    public static readonly OpenNettyCapability StopActionScenarioState = new("Stop action scenario state");
 
     /// <summary>
-    /// Toggle scenario.
+    /// Stop/up/down scenario control.
     /// </summary>
-    public static readonly OpenNettyCapability ToggleScenario = new("Toggle scenario");
+    public static readonly OpenNettyCapability StopUpDownScenarioControl = new("Stop/up/down scenario control");
+
+    /// <summary>
+    /// Stop/up/down scenario state.
+    /// </summary>
+    public static readonly OpenNettyCapability StopUpDownScenarioState = new("Stop/up/down scenario state");
+
+    /// <summary>
+    /// Timed scenario control.
+    /// </summary>
+    public static readonly OpenNettyCapability TimedScenarioControl = new("Timed scenario control");
+
+    /// <summary>
+    /// Timed scenario state.
+    /// </summary>
+    public static readonly OpenNettyCapability TimedScenarioState = new("Timed scenario state");
+
+    /// <summary>
+    /// Toggle scenario state.
+    /// </summary>
+    public static readonly OpenNettyCapability ToggleScenarioState = new("Toggle scenario state");
 
     /// <summary>
     /// Unit description.
@@ -175,11 +225,6 @@ public static class OpenNettyCapabilities
     /// Water heating.
     /// </summary>
     public static readonly OpenNettyCapability WaterHeating = new("Water heating");
-
-    /// <summary>
-    /// Wireless burglar alarm scenario.
-    /// </summary>
-    public static readonly OpenNettyCapability WirelessBurglarAlarmScenario = new("Wireless burglar alarm scenario");
 
     /// <summary>
     /// Wireless burglar alarm state.

--- a/src/OpenNetty/OpenNettyCapability.cs
+++ b/src/OpenNetty/OpenNettyCapability.cs
@@ -37,9 +37,9 @@ public readonly struct OpenNettyCapability : IEquatable<OpenNettyCapability>
     public override int GetHashCode() => Name?.GetHashCode() ?? 0;
 
     /// <summary>
-    /// Computes the <see cref="string"/> representation of the current capability.
+    /// Returns a human-readable representation of the current capability.
     /// </summary>
-    /// <returns>The <see cref="string"/> representation of the current capability.</returns>
+    /// <returns>A human-readable representation of the current capability.</returns>
     public override string ToString() => Name?.ToString() ?? string.Empty;
 
     /// <summary>

--- a/src/OpenNetty/OpenNettyCommands.cs
+++ b/src/OpenNetty/OpenNettyCommands.cs
@@ -200,6 +200,11 @@ public static class OpenNettyCommands
         /// Close binding (WHAT = 36).
         /// </summary>
         public static readonly OpenNettyCommand CloseBinding = new(OpenNettyCategories.Scenarios, "36");
+
+        /// <summary>
+        /// Cancel binding (WHAT = 37).
+        /// </summary>
+        public static readonly OpenNettyCommand CancelBinding = new(OpenNettyCategories.Scenarios, "37");
     }
 
     /// <summary>

--- a/src/OpenNetty/OpenNettyConfiguration.cs
+++ b/src/OpenNetty/OpenNettyConfiguration.cs
@@ -7,6 +7,7 @@
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Globalization;
+using System.Text;
 using Microsoft.Extensions.Options;
 
 namespace OpenNetty;
@@ -21,36 +22,28 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        // For Nitoo and Zigbee devices, add implicit endpoints for all the units present
-        // in the device definition but that have not been explicitly added by the user.
         foreach (var device in options.Devices)
         {
             if (device.Definition.Protocol is not (OpenNettyProtocol.Nitoo or OpenNettyProtocol.Zigbee) ||
-                device.Definition.Units.Length is 0 ||
                 string.IsNullOrEmpty(device.SerialNumber))
             {
                 continue;
             }
 
-            foreach (var definition in device.Definition.Units)
+            // If an endpoint targeting the device was configured by the user, do not override it.
+            if (!options.Endpoints.Exists(endpoint => endpoint.Device == device && endpoint.Unit is null))
             {
-                // If an endpoint targeting the unit was configured by the user, do not override it.
-                if (options.Endpoints.Exists(endpoint => endpoint.Device == device && endpoint.Unit?.Definition == definition))
-                {
-                    continue;
-                }
-
                 options.Endpoints.Add(new OpenNettyEndpoint
                 {
                     Address = device.Definition.Protocol switch
                     {
                         OpenNettyProtocol.Nitoo => OpenNettyAddress.FromNitooAddress(
                             identifier: uint.Parse(device.SerialNumber ?? throw new InvalidOperationException(SR.FormatID0089("SerialNumber")), CultureInfo.InvariantCulture),
-                            unit      : definition.Id),
+                            unit      : 0),
 
                         OpenNettyProtocol.Zigbee => OpenNettyAddress.FromHexadecimalZigbeeAddress(
                             identifier: device.SerialNumber ?? throw new InvalidOperationException(SR.FormatID0094("SerialNumber")),
-                            unit      : definition.Id),
+                            unit      : 0),
 
                         _ => null
                     },
@@ -58,16 +51,67 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
                     Device = device,
                     Gateway = null,
                     Medium = device.Definition.Medium,
-                    Name = null,
+                    Name = ComputeDefaultEndpointName(device),
                     Protocol = device.Definition.Protocol,
-                    Settings = ImmutableDictionary.Create<OpenNettySetting, string>(),
-                    Unit = device.Units.SingleOrDefault(unit => unit.Definition == definition) ?? new OpenNettyUnit
-                    {
-                        Definition = definition,
-                        Scenarios = [],
-                        Settings = ImmutableDictionary.Create<OpenNettySetting, string>()
-                    }
+                    Settings = ImmutableDictionary.Create<OpenNettySetting, string>()
                 });
+
+                static string ComputeDefaultEndpointName(OpenNettyDevice device)
+                    => new StringBuilder(Enum.GetName(device.Definition.Protocol))
+                        .Append('/')
+                        .Append(device.SerialNumber)
+                        .ToString();
+            }
+
+            // For Nitoo and Zigbee devices, add implicit endpoints for all the units present
+            // in the device definition but that have not been explicitly added by the user.
+            if (device.Definition.Units.Length is not 0)
+            {
+                foreach (var definition in device.Definition.Units)
+                {
+                    // If an endpoint targeting the unit was configured by the user, do not override it.
+                    if (options.Endpoints.Exists(endpoint => endpoint.Device == device && endpoint.Unit?.Definition == definition))
+                    {
+                        continue;
+                    }
+
+                    options.Endpoints.Add(new OpenNettyEndpoint
+                    {
+                        Address = device.Definition.Protocol switch
+                        {
+                            OpenNettyProtocol.Nitoo => OpenNettyAddress.FromNitooAddress(
+                                identifier: uint.Parse(device.SerialNumber ?? throw new InvalidOperationException(SR.FormatID0089("SerialNumber")), CultureInfo.InvariantCulture),
+                                unit      : definition.Id),
+
+                            OpenNettyProtocol.Zigbee => OpenNettyAddress.FromHexadecimalZigbeeAddress(
+                                identifier: device.SerialNumber ?? throw new InvalidOperationException(SR.FormatID0094("SerialNumber")),
+                                unit      : definition.Id),
+
+                            _ => null
+                        },
+                        Capabilities = [],
+                        Device = device,
+                        Gateway = null,
+                        Medium = device.Definition.Medium,
+                        Name = ComputeDefaultEndpointName(device, definition),
+                        Protocol = device.Definition.Protocol,
+                        Settings = ImmutableDictionary.Create<OpenNettySetting, string>(),
+                        Unit = device.Units.SingleOrDefault(unit => unit.Definition == definition) ?? new OpenNettyUnit
+                        {
+                            Definition = definition,
+                            Scenarios = [],
+                            Settings = ImmutableDictionary.Create<OpenNettySetting, string>()
+                        }
+                    });
+
+                    static string ComputeDefaultEndpointName(OpenNettyDevice device, OpenNettyUnitDefinition unit)
+                        => new StringBuilder(Enum.GetName(device.Definition.Protocol))
+                            .Append('/')
+                            .Append(device.SerialNumber)
+                            .Append('/')
+                            .Append(unit.Id)
+                            .ToString();
+                }
             }
         }
     }
@@ -76,6 +120,17 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
     public ValidateOptionsResult Validate(string? name, OpenNettyOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
+
+        foreach (var device in options.Devices)
+        {
+            if (!string.IsNullOrEmpty(device.SerialNumber) && device.SerialNumber.Any(static character =>
+                character is not ((>= '0' and <= '9') or
+                                  (>= 'a' and <= 'f') or
+                                  (>= 'A' and <= 'F'))))
+            {
+                return ValidateOptionsResult.Fail(SR.FormatID2006(device.SerialNumber));
+            }
+        }
 
         foreach (var endpoint in options.Endpoints)
         {
@@ -103,10 +158,10 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
             {
                 case null or { Length: 0 }: break;
 
-                case string type when type is not (
+                case string mode when mode is not (
                     OpenNettySettings.SwitchModes.Default or
                     OpenNettySettings.SwitchModes.PushButton):
-                    return ValidateOptionsResult.Fail(SR.FormatID2004(endpoint.Name, type));
+                    return ValidateOptionsResult.Fail(SR.FormatID2004(endpoint.Name, mode));
             }
 
             static bool SupportsLightControl(OpenNettyEndpoint endpoint) =>

--- a/src/OpenNetty/OpenNettyController.cs
+++ b/src/OpenNetty/OpenNettyController.cs
@@ -191,18 +191,18 @@ public class OpenNettyController
     }
 
     /// <summary>
-    /// Dispatches a virtual basic (action) scenario for the specified endpoint.
+    /// Dispatches a virtual action scenario for the specified endpoint.
     /// </summary>
     /// <param name="endpoint">The endpoint.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
-    public virtual async ValueTask DispatchBasicScenarioAsync(
+    public virtual async ValueTask DispatchActionScenarioAsync(
         OpenNettyEndpoint endpoint,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(endpoint);
 
-        if (!endpoint.HasCapability(OpenNettyCapabilities.BasicScenario))
+        if (!endpoint.HasCapability(OpenNettyCapabilities.ActionScenarioControl))
         {
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
         }
@@ -210,18 +210,6 @@ public class OpenNettyController
         await _service.ExecuteCommandAsync(
             protocol         : endpoint.Protocol,
             command          : OpenNettyCommands.Scenario.Action,
-            address          : endpoint.Address,
-            medium           : endpoint.Medium,
-            mode             : OpenNettyMode.Broadcast,
-            gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
-            cancellationToken: cancellationToken);
-
-        await Task.Delay(TimeSpan.FromSeconds(0.5), cancellationToken);
-
-        await _service.ExecuteCommandAsync(
-            protocol         : endpoint.Protocol,
-            command          : OpenNettyCommands.Scenario.StopAction,
             address          : endpoint.Address,
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Broadcast,
@@ -242,7 +230,7 @@ public class OpenNettyController
     {
         ArgumentNullException.ThrowIfNull(endpoint);
 
-        if (!endpoint.HasCapability(OpenNettyCapabilities.OnOffScenario))
+        if (!endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioControl))
         {
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
         }
@@ -270,7 +258,7 @@ public class OpenNettyController
     {
         ArgumentNullException.ThrowIfNull(endpoint);
 
-        if (!endpoint.HasCapability(OpenNettyCapabilities.OnOffScenario))
+        if (!endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioControl))
         {
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
         }
@@ -293,34 +281,22 @@ public class OpenNettyController
     /// <param name="duration">The scenario duration.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
-    public virtual async ValueTask DispatchProgressiveScenarioAsync(
+    public virtual ValueTask DispatchProgressiveScenarioAsync(
         OpenNettyEndpoint endpoint,
         TimeSpan duration,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(endpoint);
 
-        if (!endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenario))
+        if (!endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenarioControl))
         {
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
         }
 
-        await _service.ExecuteCommandAsync(
+        return _service.ExecuteCommandAsync(
             protocol         : endpoint.Protocol,
             command          : OpenNettyCommands.Scenario.ActionInTime.WithParameters(
                 /* TIME: */ ((long) (duration.TotalSeconds * 5 + .5)).ToString(CultureInfo.InvariantCulture)),
-            address          : endpoint.Address,
-            medium           : endpoint.Medium,
-            mode             : OpenNettyMode.Broadcast,
-            gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
-            cancellationToken: cancellationToken);
-
-        await Task.Delay(TimeSpan.FromSeconds(0.5), cancellationToken);
-
-        await _service.ExecuteCommandAsync(
-            protocol         : endpoint.Protocol,
-            command          : OpenNettyCommands.Scenario.StopAction,
             address          : endpoint.Address,
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Broadcast,
@@ -341,7 +317,7 @@ public class OpenNettyController
     {
         ArgumentNullException.ThrowIfNull(endpoint);
 
-        if (!endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenario))
+        if (!endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioControl))
         {
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
         }
@@ -369,7 +345,7 @@ public class OpenNettyController
     {
         ArgumentNullException.ThrowIfNull(endpoint);
 
-        if (!endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenario))
+        if (!endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioControl))
         {
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
         }
@@ -397,7 +373,7 @@ public class OpenNettyController
     {
         ArgumentNullException.ThrowIfNull(endpoint);
 
-        if (!endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenario))
+        if (!endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioControl))
         {
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
         }
@@ -414,40 +390,56 @@ public class OpenNettyController
     }
 
     /// <summary>
-    /// Dispatches a virtual timed scenario for the specified endpoint.
+    /// Dispatches a virtual stop action scenario for the specified endpoint.
     /// </summary>
     /// <param name="endpoint">The endpoint.</param>
-    /// <param name="duration">The duration after which associated devices will change their state.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
-    public virtual async ValueTask DispatchTimedScenarioAsync(
+    public virtual ValueTask DispatchStopActionScenarioAsync(
         OpenNettyEndpoint endpoint,
-        TimeSpan duration,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(endpoint);
 
-        if (!endpoint.HasCapability(OpenNettyCapabilities.TimedScenario))
+        if (!endpoint.HasCapability(OpenNettyCapabilities.StopActionScenarioControl))
         {
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
         }
 
-        await _service.ExecuteCommandAsync(
+        return _service.ExecuteCommandAsync(
             protocol         : endpoint.Protocol,
-            command          : OpenNettyCommands.Scenario.ActionForTime.WithParameters(
-                /* TIME: */ ((long) (duration.TotalSeconds * 5 + .5)).ToString(CultureInfo.InvariantCulture)),
+            command          : OpenNettyCommands.Scenario.StopAction,
             address          : endpoint.Address,
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Broadcast,
             gateway          : endpoint.Gateway,
             options          : OpenNettyTransmissionOptions.None,
             cancellationToken: cancellationToken);
+    }
 
-        await Task.Delay(TimeSpan.FromSeconds(0.5), cancellationToken);
+    /// <summary>
+    /// Dispatches a virtual timed scenario for the specified endpoint.
+    /// </summary>
+    /// <param name="endpoint">The endpoint.</param>
+    /// <param name="duration">The duration after which associated devices will change their state.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
+    public virtual ValueTask DispatchTimedScenarioAsync(
+        OpenNettyEndpoint endpoint,
+        TimeSpan duration,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
 
-        await _service.ExecuteCommandAsync(
+        if (!endpoint.HasCapability(OpenNettyCapabilities.TimedScenarioControl))
+        {
+            throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
+        }
+
+        return _service.ExecuteCommandAsync(
             protocol         : endpoint.Protocol,
-            command          : OpenNettyCommands.Scenario.StopAction,
+            command          : OpenNettyCommands.Scenario.ActionForTime.WithParameters(
+                /* TIME: */ ((long) (duration.TotalSeconds * 5 + .5)).ToString(CultureInfo.InvariantCulture)),
             address          : endpoint.Address,
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Broadcast,
@@ -1059,6 +1051,84 @@ public class OpenNettyController
             cancellationToken: cancellationToken);
 
         return OpenNettyModels.Diagnostics.DeviceDescription.CreateFromDeviceDescription(values);
+    }
+
+    /// <summary>
+    /// Resolves the firmware version of the specified endpoint.
+    /// </summary>
+    /// <param name="endpoint">The endpoint.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous
+    /// operation and whose result returns the firmware version of the specified endpoint.
+    /// </returns>
+    public virtual async ValueTask<Version> GetFirmwareVersionAsync(
+        OpenNettyEndpoint endpoint,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (endpoint.HasCapability(OpenNettyCapabilities.FirmwareVersion))
+        {
+            var values = await _service.GetDimensionAsync(
+                protocol         : endpoint.Protocol,
+                dimension        : OpenNettyDimensions.Management.FirmwareVersion,
+                address          : endpoint.Address,
+                medium           : endpoint.Medium,
+                mode             : null,
+                gateway          : endpoint.Gateway,
+                options          : OpenNettyTransmissionOptions.None,
+                cancellationToken: cancellationToken);
+
+            return new Version(
+                major: int.Parse(values[0], CultureInfo.InvariantCulture),
+                minor: int.Parse(values[1], CultureInfo.InvariantCulture),
+                build: int.Parse(values[2], CultureInfo.InvariantCulture));
+        }
+
+        else if (endpoint.HasCapability(OpenNettyCapabilities.DeviceDescription))
+        {
+            var description = await GetDeviceDescriptionAsync(endpoint, cancellationToken);
+            return description.Version;
+        }
+
+        throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
+    }
+
+    /// <summary>
+    /// Resolves the hardware version of the specified endpoint.
+    /// </summary>
+    /// <param name="endpoint">The endpoint.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous
+    /// operation and whose result returns the hardware version of the specified endpoint.
+    /// </returns>
+    public virtual async ValueTask<Version> GetHardwareVersionAsync(
+        OpenNettyEndpoint endpoint,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (!endpoint.HasCapability(OpenNettyCapabilities.HardwareVersion))
+        {
+            throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
+        }
+
+        var values = await _service.GetDimensionAsync(
+            protocol         : endpoint.Protocol,
+            dimension        : OpenNettyDimensions.Management.HardwareVersion,
+            address          : endpoint.Address,
+            medium           : endpoint.Medium,
+            mode             : null,
+            gateway          : endpoint.Gateway,
+            options          : OpenNettyTransmissionOptions.None,
+            cancellationToken: cancellationToken);
+
+        return new Version(
+            major: int.Parse(values[0], CultureInfo.InvariantCulture),
+            minor: int.Parse(values[1], CultureInfo.InvariantCulture),
+            build: int.Parse(values[2], CultureInfo.InvariantCulture));
     }
 
     /// <summary>

--- a/src/OpenNetty/OpenNettyCoordinator.cs
+++ b/src/OpenNetty/OpenNettyCoordinator.cs
@@ -60,7 +60,6 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     Type    : OpenNettyMessageType.BusCommand    or
                               OpenNettyMessageType.DimensionRead or
                               OpenNettyMessageType.DimensionSet,
-                    Address : not null,
                     Mode    : OpenNettyMode.Broadcast } message }
                 => AsyncObservable.Return<(OpenNettyNotification Notification, OpenNettyMessage Message)>((notification, message)),
 
@@ -70,8 +69,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     Protocol: OpenNettyProtocol.Scs,
                     Type    : OpenNettyMessageType.BusCommand    or
                               OpenNettyMessageType.DimensionRead or
-                              OpenNettyMessageType.DimensionSet,
-                    Address : not null } message }
+                              OpenNettyMessageType.DimensionSet } message }
                 => AsyncObservable.Return<(OpenNettyNotification Notification, OpenNettyMessage Message)>((notification, message)),
 
             OpenNettyNotifications.MessageReceived {
@@ -80,8 +78,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     Protocol: OpenNettyProtocol.Zigbee,
                     Type    : OpenNettyMessageType.BusCommand    or
                               OpenNettyMessageType.DimensionRead or
-                              OpenNettyMessageType.DimensionSet,
-                    Address : not null } message }
+                              OpenNettyMessageType.DimensionSet } message }
                 => AsyncObservable.Return<(OpenNettyNotification Notification, OpenNettyMessage Message)>((notification, message)),
 
             // Note: unlike SCS (and Zigbee devices when the supervision mode is enabled), Nitoo devices
@@ -93,8 +90,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                 Session.Type: OpenNettySessionType.Generic,
                 Message: {
                     Protocol: OpenNettyProtocol.Nitoo,
-                    Type    : OpenNettyMessageType.BusCommand or OpenNettyMessageType.DimensionSet,
-                    Address : not null } message }
+                    Type    : OpenNettyMessageType.BusCommand or OpenNettyMessageType.DimensionSet } message }
                 => AsyncObservable.Return<(OpenNettyNotification Notification, OpenNettyMessage Message)>((notification, message)),
 
             _ => AsyncObservable.Empty<(OpenNettyNotification Notification, OpenNettyMessage Message)>()
@@ -134,7 +130,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     // If the message was received and was emitted by the source using
                     // a broadcast transmission, it is considered as an ON/OFF scenario.
                     if (notification is OpenNettyNotifications.MessageReceived && mode is OpenNettyMode.Broadcast &&
-                        endpoint.HasCapability(OpenNettyCapabilities.OnOffScenario))
+                        endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioState))
                     {
                         if (command == OpenNettyCommands.Lighting.On)
                         {
@@ -507,7 +503,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                         return;
                     }
 
-                    if (endpoint.HasCapability(OpenNettyCapabilities.ToggleScenario))
+                    if (endpoint.HasCapability(OpenNettyCapabilities.ToggleScenarioState))
                     {
                         await _events.PublishAsync(new ToggleScenarioReportedEventArgs(endpoint));
                     }
@@ -542,7 +538,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     // If the message was received and was emitted by the source using a
                     // broadcast transmission, it is considered as an STOP/UP/DOWN scenario.
                     if (notification is OpenNettyNotifications.MessageReceived && mode is OpenNettyMode.Broadcast &&
-                        endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenario))
+                        endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioState))
                     {
                         if (command == OpenNettyCommands.Automation.Stop)
                         {
@@ -1183,47 +1179,32 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                 {
                     // Ignore the message if the corresponding endpoint couldn't be resolved or if it
                     // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
+                    //
+                    // Note: while the battery level is reported using a unit-specific address, it applies to the entire
+                    // device: this task retrieves the device endpoint and, if available, report its battery level.
+                    var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromDecimalZigbeeAddress(
+                        OpenNettyAddress.ToZigbeeAddress(address).Identifier));
+                    
                     if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
                     {
                         return;
                     }
 
-                    List<Task> tasks = [];
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.Battery))
+                    if (endpoint.HasCapability(OpenNettyCapabilities.BatteryLevel))
                     {
-                        tasks.Add(ReportBatteryLevelAsync(endpoint, CancellationToken.None).AsTask());
-                    }
-
-                    tasks.Add(Task.Run(async () =>
-                    {
-                        // Note: while the battery level is reported using a unit-specific address, it applies to the entire
-                        // device: this task retrieves the device endpoint and, if available, report its battery level.
-                        var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromDecimalZigbeeAddress(
-                            OpenNettyAddress.ToZigbeeAddress(address).Identifier));
-
-                        if (endpoint is not null && endpoint.HasCapability(OpenNettyCapabilities.Battery))
+                        await _events.PublishAsync(new BatteryLevelReportedEventArgs(endpoint, value switch
                         {
-                            await ReportBatteryLevelAsync(endpoint, CancellationToken.None);
-                        }
-                    }));
-
-                    async ValueTask ReportBatteryLevelAsync(OpenNettyEndpoint endpoint, CancellationToken cancellationToken)
-                        => await _events.PublishAsync(new BatteryLevelReportedEventArgs(endpoint, value switch
-                        {
-                            "0" => 0,
+                            "0" => 5,
                             "1" => 33,
                             "2" => 66,
                             "3" => 100,
 
                             _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0075))
-                        }), cancellationToken);
+                        }));
+                    }
                     break;
                 }
 
-                // Note: Nitoo radio devices don't directly expose the battery level but send a special frame
-                // header converted to an OpenWebNet "BATTERY WEAK" BUS COMMAND when the battery is low.
                 case (OpenNettyNotifications.MessageReceived,
                       OpenNettyMessage { Protocol: OpenNettyProtocol.Nitoo,
                                          Type    : OpenNettyMessageType.BusCommand,
@@ -1239,9 +1220,38 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                         return;
                     }
 
-                    if (endpoint.HasCapability(OpenNettyCapabilities.Battery))
+                    if (endpoint.HasCapability(OpenNettyCapabilities.BatteryAlert))
                     {
-                        await _events.PublishAsync(new BatteryLevelReportedEventArgs(endpoint, 5));
+                        await _events.PublishAsync(new BatteryAlertReportedEventArgs(endpoint));
+                    }
+                    break;
+                }
+
+                // Note: uptime DIMENSION READ messages never include an address, as they are sent by the gateway itself.
+                case (OpenNettyNotifications.MessageReceived,
+                      OpenNettyMessage { Protocol : OpenNettyProtocol.Nitoo or OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee,
+                                         Type     : OpenNettyMessageType.DimensionRead,
+                                         Address  : null,
+                                         Dimension: OpenNettyDimension dimension,
+                                         Values   : [{ Length: > 0 }, { Length: > 0 }, { Length: > 0 }, { Length: > 0 }] values })
+                    when dimension == OpenNettyDimensions.Management.Uptime:
+                {
+                    // Resolve the endpoint associated with the gateway that received the DIMENSION READ message.
+                    var endpoint = await _manager.FindEndpointAsync(endpoint =>
+                        endpoint.Device == arguments.Notification.Gateway.Device && endpoint.Unit is null);
+
+                    if (endpoint is null)
+                    {
+                        return;
+                    }
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.Uptime))
+                    {
+                        await _events.PublishAsync(new UptimeReportedEventArgs(endpoint, new TimeSpan(
+                            days   : int.Parse(values[0], CultureInfo.InvariantCulture),
+                            hours  : int.Parse(values[1], CultureInfo.InvariantCulture),
+                            minutes: int.Parse(values[2], CultureInfo.InvariantCulture),
+                            seconds: int.Parse(values[3], CultureInfo.InvariantCulture))));
                     }
                     break;
                 }
@@ -1252,7 +1262,8 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Command : OpenNettyCommand command,
                                          Address : OpenNettyAddress address })
                     when command == OpenNettyCommands.Scenario.OpenBinding ||
-                         command == OpenNettyCommands.Scenario.CloseBinding:
+                         command == OpenNettyCommands.Scenario.CloseBinding ||
+                         command == OpenNettyCommands.Scenario.CancelBinding:
                 {
                     // Ignore the message if the corresponding endpoint couldn't be resolved or if it
                     // was received by a different gateway than the one associated with the endpoint.
@@ -1269,9 +1280,14 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                             await _events.PublishAsync(new BindingOpenEventArgs(endpoint));
                         }
 
-                        else
+                        else if (command == OpenNettyCommands.Scenario.CloseBinding)
                         {
                             await _events.PublishAsync(new BindingClosedEventArgs(endpoint));
+                        }
+
+                        else if (command == OpenNettyCommands.Scenario.CancelBinding)
+                        {
+                            await _events.PublishAsync(new BindingCanceledEventArgs(endpoint));
                         }
                     }
                     break;
@@ -1315,7 +1331,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                         return;
                     }
 
-                    if (endpoint.HasCapability(OpenNettyCapabilities.DimmingScenario))
+                    if (endpoint.HasCapability(OpenNettyCapabilities.DimmingScenarioState))
                     {
                         var step = int.Parse(value, CultureInfo.InvariantCulture);
                         if (step is >= 128)
@@ -1355,7 +1371,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
 
                     if (command == OpenNettyCommands.Scenario.Action)
                     {
-                        if (!endpoint.HasCapability(OpenNettyCapabilities.BasicScenario))
+                        if (!endpoint.HasCapability(OpenNettyCapabilities.ActionScenarioState))
                         {
                             break;
                         }
@@ -1368,40 +1384,37 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                         // Note: since they are radiofrequency devices, the current state of Nitoo wireless burglar alarms
                         // cannot be retrieved using a unit description request. To inform devices associated using a
                         // PnL scenario of a state change, Nitoo alarms broadcast it using unit-specific ACTION scenarios.
-                        if (endpoint.HasCapability(OpenNettyCapabilities.WirelessBurglarAlarmScenario))
+                        tasks.Add(Task.Run(async () =>
                         {
-                            tasks.Add(Task.Run(async () =>
+                            var (identifier, unit) = OpenNettyAddress.ToNitooAddress(address);
+                            if (unit is not (>= 4 and <= 9))
                             {
-                                var (identifier, unit) = OpenNettyAddress.ToNitooAddress(address);
+                                return;
+                            }
 
-                                var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(identifier));
-                                if (endpoint is null || !endpoint.HasCapability(OpenNettyCapabilities.WirelessBurglarAlarmState))
-                                {
-                                    return;
-                                }
+                            var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(identifier));
+                            if (endpoint is null || !endpoint.HasCapability(OpenNettyCapabilities.WirelessBurglarAlarmState))
+                            {
+                                return;
+                            }
 
-                                var state = unit switch
-                                {
-                                    4 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.Armed,
-                                    5 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.Disarmed,
-                                    6 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.PartiallyArmed,
-                                    7 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.Triggered,
-                                    8 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.ExitDelayElapsed,
-                                    9 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.EventDetected,
-                                    _ => null as OpenNettyModels.Alarm.WirelessBurglarAlarmState?
-                                };
+                            await _events.PublishAsync(new WirelessBurglarAlarmStateReportedEventArgs(endpoint, unit switch
+                            {
+                                4 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.Armed,
+                                5 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.Disarmed,
+                                6 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.PartiallyArmed,
+                                7 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.Triggered,
+                                8 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.ExitDelayElapsed,
+                                9 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.EventDetected,
 
-                                if (state is not null)
-                                {
-                                    await _events.PublishAsync(new WirelessBurglarAlarmStateReportedEventArgs(endpoint, state.Value));
-                                }
+                                _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0075))
                             }));
-                        }
+                        }));
                     }
 
                     else if (command.Value == OpenNettyCommands.Scenario.ActionForTime.Value)
                     {
-                        if (!endpoint.HasCapability(OpenNettyCapabilities.TimedScenario))
+                        if (!endpoint.HasCapability(OpenNettyCapabilities.TimedScenarioState))
                         {
                             break;
                         }
@@ -1416,7 +1429,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
 
                     else if (command.Value == OpenNettyCommands.Scenario.ActionInTime.Value)
                     {
-                        if (!endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenario))
+                        if (!endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenarioState))
                         {
                             break;
                         }
@@ -1645,7 +1658,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                 switch (arguments.Message)
                 {
                     case { Type: OpenNettyMessageType.BusCommand, Command: OpenNettyCommand command }
-                        when command == OpenNettyCommands.Scenario.Action && !endpoint.HasCapability(OpenNettyCapabilities.BasicScenario):
+                        when command == OpenNettyCommands.Scenario.Action && !endpoint.HasCapability(OpenNettyCapabilities.ActionScenarioState):
                         return;
 
                     case { Type: OpenNettyMessageType.BusCommand, Command: OpenNettyCommand command }
@@ -1671,18 +1684,18 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     case { Type: OpenNettyMessageType.BusCommand, Command: OpenNettyCommand command }
                         when command.Category == OpenNettyCategories.Scenarios                  &&
                              command.Value    == OpenNettyCommands.Scenario.ActionForTime.Value &&
-                            !endpoint.HasCapability(OpenNettyCapabilities.TimedScenario):
+                            !endpoint.HasCapability(OpenNettyCapabilities.TimedScenarioState):
                         return;
 
                     case { Type: OpenNettyMessageType.BusCommand, Command: OpenNettyCommand command }
                         when command.Category == OpenNettyCategories.Scenarios                 &&
                              command.Value    == OpenNettyCommands.Scenario.ActionInTime.Value &&
-                            !endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenario):
+                            !endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenarioState):
                         return;
 
                     case { Type: OpenNettyMessageType.DimensionSet, Dimension: OpenNettyDimension dimension }
                         when dimension == OpenNettyDimensions.Lighting.DimmerStep &&
-                            !endpoint.HasCapability(OpenNettyCapabilities.DimmingScenario):
+                            !endpoint.HasCapability(OpenNettyCapabilities.DimmingScenarioState):
                         return;
                 }
 
@@ -1779,7 +1792,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                 return;
             }
 
-            if (!endpoint.HasCapability(OpenNettyCapabilities.TimedScenario))
+            if (!endpoint.HasCapability(OpenNettyCapabilities.TimedScenarioState))
             {
                 return;
             }

--- a/src/OpenNetty/OpenNettyDevice.cs
+++ b/src/OpenNetty/OpenNettyDevice.cs
@@ -57,13 +57,22 @@ public sealed class OpenNettyDevice : IEquatable<OpenNettyDevice>
     public string? GetStringSetting(OpenNettySetting setting) => TryGetSetting(setting, out string? value) ? value : null;
 
     /// <summary>
+    /// Determines whether the device has the specified capability.
+    /// </summary>
+    /// <param name="capability">The capability name.</param>
+    /// <returns>
+    /// <see langword="true"/> if the device has the specified capability, <see langword="false"/> otherwise.
+    /// </returns>
+    public bool HasCapability(OpenNettyCapability capability) => Definition.HasCapability(capability);
+
+    /// <summary>
     /// Tries to resolve the specified setting from the settings.
     /// </summary>
     /// <param name="setting">The setting name.</param>
     /// <param name="value">The setting value, or <see langword="null"/> if it was not found.</param>
     /// <returns><see langword="true"/> if the setting was found, <see langword="false"/> otherwise.</returns>
     public bool TryGetSetting(OpenNettySetting setting, [NotNullWhen(true)] out string? value)
-        => Settings.TryGetValue(setting, out value);
+        => Settings.TryGetValue(setting, out value) || Definition.Settings.TryGetValue(setting, out value);
 
     /// <inheritdoc/>
     public bool Equals(OpenNettyDevice? other)

--- a/src/OpenNetty/OpenNettyDeviceDefinition.cs
+++ b/src/OpenNetty/OpenNettyDeviceDefinition.cs
@@ -19,6 +19,11 @@ public sealed class OpenNettyDeviceDefinition : IEquatable<OpenNettyDeviceDefini
     public required ImmutableHashSet<OpenNettyCapability> Capabilities { get; init; } = [];
 
     /// <summary>
+    /// Gets or sets the description associated with the unit definition.
+    /// </summary>
+    public required string Description { get; init; }
+
+    /// <summary>
     /// Gets or sets the identities associated with the device definition.
     /// </summary>
     public required ImmutableArray<OpenNettyIdentity> Identities { get; init; }
@@ -59,6 +64,7 @@ public sealed class OpenNettyDeviceDefinition : IEquatable<OpenNettyDeviceDefini
 
         return other is not null &&
             Capabilities.Count == other.Capabilities.Count && Capabilities.Except(other.Capabilities).IsEmpty &&
+            string.Equals(Description, other.Description, StringComparison.OrdinalIgnoreCase) &&
             Identities.Length == other.Identities.Length && !Identities.Except(other.Identities).Any() &&
             Medium == other.Medium &&
             Protocol == other.Protocol &&
@@ -80,6 +86,8 @@ public sealed class OpenNettyDeviceDefinition : IEquatable<OpenNettyDeviceDefini
         {
             hash.Add(capability);
         }
+
+        hash.Add(Description);
 
         hash.Add(Identities.Length);
         foreach (var identity in Identities)

--- a/src/OpenNetty/OpenNettyDevices.cs
+++ b/src/OpenNetty/OpenNettyDevices.cs
@@ -136,6 +136,7 @@ public static class OpenNettyDevices
             {
                 Brand = Enum.Parse<OpenNettyBrand>((string) identity.Attribute("Brand")!),
                 Collection = (string?) identity.Attribute("Collection"),
+                Description = (string) identity.Attribute("Description")!,
                 Model = (string) identity.Attribute("Model")!
             });
         }
@@ -153,6 +154,7 @@ public static class OpenNettyDevices
         return new OpenNettyDeviceDefinition
         {
             Capabilities = [.. capabilities],
+            Description = (string) node.Attribute("Description")!,
             Identities = [.. identities],
             Medium = Enum.Parse<OpenNettyMedium>((string) node.Attribute("Medium")!),
             Protocol = Enum.Parse<OpenNettyProtocol>((string) node.Attribute("Protocol")!),
@@ -181,6 +183,7 @@ public static class OpenNettyDevices
         {
             AssociatedUnitId = (byte?) (uint?) node.Attribute("AssociatedUnitId"),
             Capabilities = [.. capabilities],
+            Description = (string) node.Attribute("Description")!,
             Id = (byte) (uint) node.Attribute("Id")!,
             Settings = settings.ToImmutableDictionary()
         };

--- a/src/OpenNetty/OpenNettyDevices.xml
+++ b/src/OpenNetty/OpenNettyDevices.xml
@@ -9,96 +9,149 @@
   -->
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
-    <Identity Brand="Legrand" Collection="Lexic" Model="03600" />
+    <Identity Brand="Legrand" Collection="Lexic" Model="03600" Description="2-gang DIN rail switch" />
 
     <Capability Name="Device description" />
 
-    <Unit Id="1" AssociatedUnitId="3">
-      <Capability Name="Dimming scenario" />
-      <Capability Name="On/off scenario" />
+    <Unit Id="1" AssociatedUnitId="3" Description="Local control for output 1 and lighting scenario">
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="On/off scenario control" />
+      <Capability Name="On/off scenario state" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="ON/OFF/dimming command 1" />
     </Unit>
 
-    <Unit Id="2" AssociatedUnitId="4">
-      <Capability Name="Dimming scenario" />
-      <Capability Name="On/off scenario" />
+    <Unit Id="2" AssociatedUnitId="4" Description="Local control for output 2 and lighting scenario">
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="On/off scenario control" />
+      <Capability Name="On/off scenario state" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="ON/OFF/dimming command 2" />
     </Unit>
 
-    <Unit Id="3">
+    <Unit Id="3" Description="Output 1">
       <Capability Name="Memory reading" />
       <Capability Name="Memory writing" />
       <Capability Name="On/off switch state" />
       <Capability Name="On/off switch control" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Output 1" />
     </Unit>
 
-    <Unit Id="4">
+    <Unit Id="4" Description="Output 2">
       <Capability Name="Memory reading" />
       <Capability Name="Memory writing" />
       <Capability Name="On/off switch state" />
       <Capability Name="On/off switch control" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Output 1" />
     </Unit>
   </Device>
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
-    <Identity Brand="Legrand" Collection="Lexic" Model="03648" />
+    <Identity Brand="Legrand" Collection="Lexic" Model="03648" Description="SCS/Nitoo gateway" />
 
     <Capability Name="Device description" />
 
-    <Unit Id="1">
-      <Capability Name="Basic scenario" />
+    <Unit Id="1" Description="Doorbell call scenario">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="doorbell" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:doorbell" />
+      <Setting Name="Home Assistant scenario name" Value="Doorbell" />
     </Unit>
 
     <Unit Id="2">
-      <Capability Name="Basic scenario" />
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
     </Unit>
 
     <Unit Id="3">
-      <Capability Name="Basic scenario" />
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
     </Unit>
 
     <Unit Id="4">
-      <Capability Name="Basic scenario" />
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
     </Unit>
 
     <Unit Id="5">
-      <Capability Name="Basic scenario" />
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
     </Unit>
 
     <Unit Id="6">
-      <Capability Name="Basic scenario" />
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
     </Unit>
 
     <Unit Id="7">
-      <Capability Name="Basic scenario" />
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
     </Unit>
 
     <Unit Id="8">
-      <Capability Name="Basic scenario" />
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
     </Unit>
 
     <Unit Id="9">
-      <Capability Name="Basic scenario" />
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
     </Unit>
 
     <Unit Id="10">
-      <Capability Name="Basic scenario" />
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
     </Unit>
 
     <Unit Id="11">
-      <Capability Name="Basic scenario" />
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
     </Unit>
 
@@ -116,18 +169,18 @@
   </Device>
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
-    <Identity Brand="Legrand" Collection="Lexic" Model="03809" />
+    <Identity Brand="Legrand" Collection="Lexic" Model="03809" Description="DIN rail energy meter" />
 
     <Capability Name="Device description" />
 
-    <Unit Id="1">
+    <Unit Id="1" Description="Water heater control">
       <Capability Name="Memory reading" />
       <Capability Name="Memory writing" />
       <Capability Name="Unit description" />
       <Capability Name="Water heating" />
     </Unit>
 
-    <Unit Id="2">
+    <Unit Id="2" Description="Pilot wire control">
       <Capability Name="Memory reading" />
       <Capability Name="Memory writing" />
       <Capability Name="Smart meter indexes" />
@@ -137,160 +190,380 @@
   </Device>
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Radio">
-    <Identity Brand="Legrand" Model="43214" />
+    <Identity Brand="Legrand" Model="43214" Description="Wireless burglar alarm" />
 
     <Capability Name="Wireless burglar alarm state" />
 
     <Unit Id="1">
-      <Capability Name="Wireless burglar alarm scenario" />
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
     </Unit>
 
     <Unit Id="2">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Wireless burglar alarm scenario" />
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
     </Unit>
 
     <Unit Id="3">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Wireless burglar alarm scenario" />
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
     </Unit>
 
-    <Unit Id="4">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Wireless burglar alarm scenario" />
+    <Unit Id="4" Description="Alarm armed scenario">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+
+      <Setting Name="Home Assistant scenario icon" Value="mdi:security" />
+      <Setting Name="Home Assistant scenario name" Value="Alarm armed" />
     </Unit>
 
-    <Unit Id="5">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Wireless burglar alarm scenario" />
+    <Unit Id="5" Description="Alarm disarmed scenario">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+
+      <Setting Name="Home Assistant scenario icon" Value="mdi:security" />
+      <Setting Name="Home Assistant scenario name" Value="Alarm disarmed" />
     </Unit>
 
-    <Unit Id="6">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Wireless burglar alarm scenario" />
+    <Unit Id="6" Description="Alarm partially armed scenario">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+
+      <Setting Name="Home Assistant scenario icon" Value="mdi:security" />
+      <Setting Name="Home Assistant scenario name" Value="Alarm partially armed" />
     </Unit>
 
-    <Unit Id="7">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Wireless burglar alarm scenario" />
+    <Unit Id="7" Description="Alarm triggered scenario">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+
+      <Setting Name="Home Assistant scenario icon" Value="mdi:security" />
+      <Setting Name="Home Assistant scenario name" Value="Alarm triggered" />
     </Unit>
 
-    <Unit Id="8">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Wireless burglar alarm scenario" />
+    <Unit Id="8" Description="Exit delay elapsed scenario">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+
+      <Setting Name="Home Assistant scenario icon" Value="mdi:security" />
+      <Setting Name="Home Assistant scenario name" Value="Exit delay elapsed" />
     </Unit>
 
-    <Unit Id="9">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Wireless burglar alarm scenario" />
+    <Unit Id="9" Description="Event detected scenario">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+
+      <Setting Name="Home Assistant scenario icon" Value="mdi:security" />
+      <Setting Name="Home Assistant scenario name" Value="Event detected" />
     </Unit>
   </Device>
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67201" />
-    <Identity Brand="Legrand" Collection="Céliane" Model="67203" />
-    <Identity Brand="Legrand" Collection="Sagane"  Model="84531" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67201" Description="1-gang switch" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67203" Description="1-gang switch with indicator light" />
+    <Identity Brand="Legrand" Collection="Sagane"  Model="84531" Description="1-gang switch" />
 
     <Capability Name="Device description" />
 
-    <Unit Id="1" AssociatedUnitId="2">
-      <Capability Name="Dimming scenario" />
-      <Capability Name="On/off scenario" />
+    <Unit Id="1" AssociatedUnitId="2" Description="Local control and lighting scenario">
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="On/off scenario control" />
+      <Capability Name="On/off scenario state" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="ON/OFF command" />
     </Unit>
 
-    <Unit Id="2">
+    <Unit Id="2" Description="Output">
       <Capability Name="Memory reading" />
       <Capability Name="Memory writing" />
       <Capability Name="On/off switch state" />
       <Capability Name="On/off switch control" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Output" />
     </Unit>
   </Device>
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67202" />
-    <Identity Brand="Legrand" Collection="Céliane" Model="67204" />
-    <Identity Brand="Legrand" Collection="Sagane"  Model="84520" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67202" Description="2-gang switch" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67204" Description="2-gang switch with indicator light" />
+    <Identity Brand="Legrand" Collection="Sagane"  Model="84520" Description="2-gang switch" />
 
     <Capability Name="Device description" />
 
-    <Unit Id="1" AssociatedUnitId="3">
-      <Capability Name="Dimming scenario" />
-      <Capability Name="On/off scenario" />
+    <Unit Id="1" AssociatedUnitId="3" Description="Local control for output 1 and lighting scenario">
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="On/off scenario control" />
+      <Capability Name="On/off scenario state" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="ON/OFF/dimming command 1" />
     </Unit>
 
-    <Unit Id="2" AssociatedUnitId="4">
-      <Capability Name="Dimming scenario" />
-      <Capability Name="On/off scenario" />
+    <Unit Id="2" AssociatedUnitId="4" Description="Local control for output 2 and lighting scenario">
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="On/off scenario control" />
+      <Capability Name="On/off scenario state" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="ON/OFF/dimming command 2" />
     </Unit>
 
-    <Unit Id="3">
+    <Unit Id="3" Description="Output 1">
       <Capability Name="Memory reading" />
       <Capability Name="Memory writing" />
       <Capability Name="On/off switch state" />
       <Capability Name="On/off switch control" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Output 1" />
     </Unit>
 
-    <Unit Id="4">
+    <Unit Id="4" Description="Output 2">
       <Capability Name="Memory reading" />
       <Capability Name="Memory writing" />
       <Capability Name="On/off switch state" />
       <Capability Name="On/off switch control" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Output 1" />
     </Unit>
   </Device>
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67208" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67208" Description="Lighting control switch" />
 
     <Capability Name="Device description" />
 
-    <Unit Id="1">
-      <Capability Name="Dimming scenario" />
-      <Capability Name="On/off scenario" />
+    <Unit Id="1" Description="Lighting scenario">
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="On/off scenario control" />
+      <Capability Name="On/off scenario state" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="ON/OFF/dimming command" />
     </Unit>
 
-    <Unit Id="2">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Dimming scenario" />
+    <Unit Id="2" Description="Multifunction scenario 1">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 1" />
     </Unit>
 
-    <Unit Id="3">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Dimming scenario" />
+    <Unit Id="3" Description="Multifunction scenario 2">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 2" />
     </Unit>
   </Device>
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67210" />
-    <Identity Brand="Legrand" Collection="Céliane" Model="67212" />
-    <Identity Brand="Legrand" Collection="Céliane" Model="67214" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67210" Description="Dimmer switch" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67212" Description="Dimmer switch with indicator light" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67214" Description="Dimmer switch with indicator light" />
 
     <Capability Name="Device description" />
 
-    <Unit Id="1" AssociatedUnitId="4">
-      <Capability Name="Dimming scenario" />
-      <Capability Name="On/off scenario" />
+    <Unit Id="1" AssociatedUnitId="4" Description="Local control and lighting scenario">
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="On/off scenario control" />
+      <Capability Name="On/off scenario state" />
+      <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="ON/OFF/dimming command" />
+    </Unit>
+
+    <Unit Id="2" AssociatedUnitId="4" Description="Local preset+ control and lighting scenario">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+      <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Preset+ command" />
+    </Unit>
+
+    <Unit Id="3" AssociatedUnitId="4" Description="Local preset- control and lighting scenario">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+      <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Preset- command" />
+    </Unit>
+
+    <Unit Id="4" Description="Output">
+      <Capability Name="Advanced dimming control" />
+      <Capability Name="Advanced dimming state" />
+      <Capability Name="Memory reading" />
+      <Capability Name="Memory writing" />
+      <Capability Name="On/off switch state" />
+      <Capability Name="On/off switch control" />
+      <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Output" />
+    </Unit>
+  </Device>
+
+  <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
+    <Identity Brand="Legrand" Collection="Céliane" Model="67215" Description="Motion sensor switch" />
+    <Identity Brand="Legrand" Collection="Sagane"  Model="84522" Description="Motion sensor switch" />
+
+    <Capability Name="Device description" />
+
+    <Unit Id="1" AssociatedUnitId="3" Description="Local control and motion detection scenario">
+      <Capability Name="Timed scenario control" />
+      <Capability Name="Timed scenario state" />
       <Capability Name="Unit description" />
     </Unit>
 
-    <Unit Id="2" AssociatedUnitId="4">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Dimming scenario" />
+    <Unit Id="2" AssociatedUnitId="3" Description="Local control and lighting scenario">
+      <Capability Name="On/off scenario control" />
+      <Capability Name="On/off scenario state" />
       <Capability Name="Unit description" />
     </Unit>
 
-    <Unit Id="3" AssociatedUnitId="4">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Dimming scenario" />
+    <Unit Id="3" Description="Output">
+      <Capability Name="Memory reading" />
+      <Capability Name="Memory writing" />
+      <Capability Name="On/off switch state" />
+      <Capability Name="On/off switch control" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Output" />
+    </Unit>
+  </Device>
+
+  <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
+    <Identity Brand="Legrand" Collection="Céliane" Model="67220" Description="Switched outlet" />
+    <Identity Brand="Legrand" Collection="Sagane"  Model="84523" Description="Switched outlet" />
+
+    <Capability Name="Device description" />
+
+    <Unit Id="1" AssociatedUnitId="2" Description="Local control and lighting scenario">
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="On/off scenario control" />
+      <Capability Name="On/off scenario state" />
+      <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="ON/OFF/dimming command" />
+    </Unit>
+
+    <Unit Id="2" Description="Output">
+      <Capability Name="On/off switch state" />
+      <Capability Name="On/off switch control" />
+      <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Output" />
+    </Unit>
+  </Device>
+
+  <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
+    <Identity Brand="Legrand" Collection="Céliane" Model="67222" Description="Dimmable switched outlet" />
+    <Identity Brand="Legrand" Collection="Sagane"  Model="84524" Description="Dimmable switched outlet" />
+
+    <Capability Name="Device description" />
+
+    <Unit Id="1" AssociatedUnitId="4" Description="Local control and lighting scenario">
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="On/off scenario control" />
+      <Capability Name="On/off scenario state" />
+      <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="ON/OFF/dimming command" />
+    </Unit>
+
+    <Unit Id="2" AssociatedUnitId="4" Description="Local preset+ control and lighting scenario">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+      <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Preset+ command" />
+    </Unit>
+
+    <Unit Id="3" AssociatedUnitId="4" Description="Local preset- control and lighting scenario">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+      <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Preset- command" />
     </Unit>
 
     <Unit Id="4">
@@ -301,147 +574,132 @@
       <Capability Name="On/off switch state" />
       <Capability Name="On/off switch control" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Output" />
     </Unit>
   </Device>
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67215" />
-    <Identity Brand="Legrand" Collection="Sagane"  Model="84522" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67280" Description="Multifunction scenario switch" />
+    <Identity Brand="Legrand" Collection="Sagane"  Model="84525" Description="Multifunction scenario switch" />
 
     <Capability Name="Device description" />
 
-    <Unit Id="1" AssociatedUnitId="3">
-      <Capability Name="Timed scenario" />
+    <Unit Id="1" Description="Multifunction scenario 1">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 1" />
     </Unit>
 
-    <Unit Id="2" AssociatedUnitId="3">
-      <Capability Name="On/off scenario" />
+    <Unit Id="2" Description="Multifunction scenario 2">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 2" />
     </Unit>
 
-    <Unit Id="3">
-      <Capability Name="Memory reading" />
-      <Capability Name="Memory writing" />
-      <Capability Name="On/off switch state" />
-      <Capability Name="On/off switch control" />
+    <Unit Id="3" Description="Multifunction scenario 3">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
-    </Unit>
-  </Device>
 
-  <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67220" />
-    <Identity Brand="Legrand" Collection="Sagane"  Model="84523" />
-
-    <Capability Name="Device description" />
-
-    <Unit Id="1" AssociatedUnitId="2">
-      <Capability Name="Dimming scenario" />
-      <Capability Name="On/off scenario" />
-      <Capability Name="Unit description" />
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 3" />
     </Unit>
 
-    <Unit Id="2">
-      <Capability Name="On/off switch state" />
-      <Capability Name="On/off switch control" />
+    <Unit Id="4" Description="Multifunction scenario 4">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Dimming scenario control" />
+      <Capability Name="Dimming scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
       <Capability Name="Unit description" />
-    </Unit>
-  </Device>
 
-  <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67222" />
-    <Identity Brand="Legrand" Collection="Sagane"  Model="84524" />
-
-    <Capability Name="Device description" />
-
-    <Unit Id="1" AssociatedUnitId="4">
-      <Capability Name="Dimming scenario" />
-      <Capability Name="On/off scenario" />
-      <Capability Name="Unit description" />
-    </Unit>
-
-    <Unit Id="2" AssociatedUnitId="4">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Dimming scenario" />
-      <Capability Name="Unit description" />
-    </Unit>
-
-    <Unit Id="3" AssociatedUnitId="4">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Dimming scenario" />
-      <Capability Name="Unit description" />
-    </Unit>
-
-    <Unit Id="4">
-      <Capability Name="Advanced dimming control" />
-      <Capability Name="Advanced dimming state" />
-      <Capability Name="Memory reading" />
-      <Capability Name="Memory writing" />
-      <Capability Name="On/off switch state" />
-      <Capability Name="On/off switch control" />
-      <Capability Name="Unit description" />
-    </Unit>
-  </Device>
-
-  <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67280" />
-    <Identity Brand="Legrand" Collection="Sagane"  Model="84525" />
-
-    <Capability Name="Device description" />
-
-    <Unit Id="1">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Dimming scenario" />
-      <Capability Name="Unit description" />
-    </Unit>
-
-    <Unit Id="2">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Dimming scenario" />
-      <Capability Name="Unit description" />
-    </Unit>
-
-    <Unit Id="3">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Dimming scenario" />
-      <Capability Name="Unit description" />
-    </Unit>
-
-    <Unit Id="4">
-      <Capability Name="Basic scenario" />
-      <Capability Name="Dimming scenario" />
-      <Capability Name="Unit description" />
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 4" />
     </Unit>
   </Device>
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Radio">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67290" />
-    <Identity Brand="Legrand" Collection="Sagane"  Model="84542" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67290" Description="Multifunction scenario switch" />
+    <Identity Brand="Legrand" Collection="Sagane"  Model="84542" Description="Multifunction scenario switch" />
 
-    <Unit Id="1">
-      <Capability Name="Basic scenario" />
+    <Capability Name="Battery alert" />
+
+    <Unit Id="1" Description="Multifunction scenario 1">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 1" />
     </Unit>
 
-    <Unit Id="2">
-      <Capability Name="Basic scenario" />
+    <Unit Id="2" Description="Multifunction scenario 2">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 2" />
     </Unit>
 
-    <Unit Id="3">
-      <Capability Name="Basic scenario" />
+    <Unit Id="3" Description="Multifunction scenario 3">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 3" />
     </Unit>
 
-    <Unit Id="4">
-      <Capability Name="Basic scenario" />
+    <Unit Id="4" Description="Multifunction scenario 4">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 4" />
     </Unit>
   </Device>
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67445" />
-    <Identity Brand="Legrand" Collection="Sagane"  Model="84530" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67445" Description="Pilot wire cable outlet" />
+    <Identity Brand="Legrand" Collection="Sagane"  Model="84530" Description="Pilot wire cable outlet" />
 
     <Capability Name="Device description" />
 
-    <Unit Id="1">
+    <Unit Id="1" Description="Local control">
       <Capability Name="Memory reading" />
       <Capability Name="Memory writing" />
       <Capability Name="Pilot wire heating" />
@@ -450,52 +708,85 @@
   </Device>
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67448" />
-    <Identity Brand="Legrand" Collection="Sagane"  Model="84529" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67448" Description="Pilot wire derogation command" />
+    <Identity Brand="Legrand" Collection="Sagane"  Model="84529" Description="Pilot wire derogation command" />
 
     <Capability Name="Device description" />
 
-    <Unit Id="1">
+    <Unit Id="1" Description="Wire pilot heating scenario">
       <Capability Name="Memory reading" />
       <Capability Name="Memory writing" />
       <Capability Name="Pilot wire heating" />
-      <Capability Name="Pilot wire scenario" />
       <Capability Name="Unit description" />
     </Unit>
   </Device>
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Radio">
-    <Identity Brand="Legrand" Collection="Plexo" Model="69510" />
+    <Identity Brand="Legrand" Collection="Plexo" Model="69510" Description="1-gang outdoor switch" />
 
-    <Unit Id="1">
+    <Unit Id="1" Description="Output">
       <Capability Name="On/off switch control" />
       <Capability Name="Unit description" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Output" />
     </Unit>
   </Device>
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Radio">
-    <Identity Brand="Legrand" Model="88205" />
+    <Identity Brand="Legrand" Model="88205" Description="Pocket scenario remote control" />
 
-    <Unit Id="1">
-      <Capability Name="Basic scenario" />
+    <Capability Name="Battery alert" />
+
+    <Unit Id="1" Description="Multifunction scenario 1">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 1" />
     </Unit>
 
-    <Unit Id="2">
-      <Capability Name="Basic scenario" />
+    <Unit Id="2" Description="Multifunction scenario 2">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 2" />
     </Unit>
 
-    <Unit Id="3">
-      <Capability Name="Basic scenario" />
+    <Unit Id="3" Description="Multifunction scenario 3">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 3" />
     </Unit>
 
-    <Unit Id="4">
-      <Capability Name="Basic scenario" />
+    <Unit Id="4" Description="Multifunction scenario 4">
+      <Capability Name="Action scenario control" />
+      <Capability Name="Action scenario state" />
+      <Capability Name="Stop action scenario control" />
+      <Capability Name="Stop action scenario state" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 4" />
     </Unit>
   </Device>
 
   <Device Series="In One by Legrand" Protocol="Nitoo" Medium="Powerline">
-    <Identity Brand="Legrand" Model="88213" />
+    <Identity Brand="Legrand" Model="88213" Description="PLC/USB gateway" />
 
+    <Capability Name="Firmware version" />
+    <Capability Name="Hardware version" />
     <Capability Name="OpenWebNet gateway" />
     <Capability Name="OpenWebNet generic session" />
 
@@ -514,16 +805,16 @@
   -->
 
   <Device Series="MyHome" Protocol="Scs" Medium="Bus">
-    <Identity Brand="BTicino" Model="F411U1" />
-    <Identity Brand="Legrand" Model="03847" />
+    <Identity Brand="BTicino" Model="F411U1" Description="1-gang DIN rail switch" />
+    <Identity Brand="Legrand" Model="03847"  Description="1-gang DIN rail switch" />
 
     <Capability Name="On/off switch state" />
     <Capability Name="On/off switch control" />
   </Device>
 
   <Device Series="MyHome" Protocol="Scs" Medium="Bus">
-    <Identity Brand="BTicino" Model="F411U2" />
-    <Identity Brand="Legrand" Model="03848" />
+    <Identity Brand="BTicino" Model="F411U2" Description="2-gang DIN rail switch" />
+    <Identity Brand="Legrand" Model="03848"  Description="2-gang DIN rail switch" />
 
     <Capability Name="Basic shutter control" />
     <Capability Name="Basic shutter state" />
@@ -532,8 +823,8 @@
   </Device>
 
   <Device Series="MyHome" Protocol="Scs" Medium="Bus">
-    <Identity Brand="BTicino" Model="F418U2" />
-    <Identity Brand="Legrand" Model="03651" />
+    <Identity Brand="BTicino" Model="F418U2" Description="2-gang DIN rail dimmer switch" />
+    <Identity Brand="Legrand" Model="03651"  Description="2-gang DIN rail dimmer switch" />
 
     <Capability Name="Advanced dimming control" />
     <Capability Name="Advanced dimming state" />
@@ -544,10 +835,11 @@
   </Device>
 
   <Device Series="MyHome" Protocol="Scs" Medium="Bus">
-    <Identity Brand="BTicino" Model="F454" />
-    <Identity Brand="Legrand" Model="03598" />
+    <Identity Brand="BTicino" Model="F454"  Description="SCS/Ethernet gateway" />
+    <Identity Brand="Legrand" Model="03598" Description="SCS/Ethernet gateway" />
 
     <Capability Name="Date/time" />
+    <Capability Name="Firmware version" />
     <Capability Name="OpenWebNet command session" />
     <Capability Name="OpenWebNet event session" />
     <Capability Name="OpenWebNet gateway" />
@@ -555,10 +847,11 @@
   </Device>
 
   <Device Series="MyHome" Protocol="Scs" Medium="Bus">
-    <Identity Brand="BTicino" Model="MH202" />
-    <Identity Brand="Legrand" Model="03535" />
+    <Identity Brand="BTicino" Model="MH202" Description="SCS scenario scheduler" />
+    <Identity Brand="Legrand" Model="03535" Description="SCS scenario scheduler" />
 
     <Capability Name="Date/time" />
+    <Capability Name="Firmware version" />
     <Capability Name="OpenWebNet command session" />
     <Capability Name="OpenWebNet event session" />
     <Capability Name="OpenWebNet gateway" />
@@ -566,7 +859,7 @@
   </Device>
 
   <Device Series="MyHome" Protocol="Scs" Medium="Bus">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67557" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67557" Description="2-channel advanced automation actuator" />
 
     <Capability Name="Advanced shutter control" />
     <Capability Name="Advanced shutter state" />
@@ -575,7 +868,7 @@
   </Device>
 
   <Device Series="MyHome" Protocol="Scs" Medium="Bus">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67561" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67561" Description="2-channel lighting/automation actuator" />
 
     <Capability Name="Basic shutter control" />
     <Capability Name="Basic shutter state" />
@@ -592,22 +885,30 @@
   -->
 
   <Device Series="MyHome Play" Protocol="Zigbee" Medium="Radio">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67223" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67223" Description="Lighting control switch" />
 
-    <Unit Id="1">
-      <Capability Name="Toggle scenario" />
+    <Capability Name="Battery level" />
+    <Capability Name="Firmware version" />
+    <Capability Name="Hardware version" />
+
+    <Unit Id="1" Description="Toggle scenario">
+      <Capability Name="Toggle scenario state" />
+      <Capability Name="Zigbee binding" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button" />
     </Unit>
-
-    <Capability Name="Battery" />
   </Device>
 
   <Device Series="MyHome Play" Protocol="Zigbee" Medium="Radio">
-    <Identity Brand="BTicino" Model="3578" />
-    <Identity Brand="Legrand" Model="88328" />
+    <Identity Brand="BTicino" Model="3578"  Description="Zigbee/USB gateway" />
+    <Identity Brand="Legrand" Model="88328" Description="Zigbee/USB gateway" />
 
+    <Capability Name="Firmware version" />
+    <Capability Name="Hardware version" />
     <Capability Name="OpenWebNet gateway" />
     <Capability Name="OpenWebNet generic session" />
-    <Capability Name="Zigbee binding" />
     <Capability Name="Zigbee supervision" />
 
     <Setting Name="Serial port baud rate" Value="19200" />
@@ -617,11 +918,22 @@
   </Device>
 
   <Device Series="MyHome Play" Protocol="Zigbee" Medium="Radio">
-    <Identity Brand="Legrand" Model="88337" />
+    <Identity Brand="Legrand" Model="88337" Description="Switched outlet" />
 
-    <Unit Id="1">
+    <Capability Name="Firmware version" />
+    <Capability Name="Hardware version" />
+
+    <Unit Id="1" Description="Local control and toggle scenario">
       <Capability Name="On/off switch state" />
       <Capability Name="On/off switch control" />
+      <Capability Name="Toggle scenario state" />
+      <Capability Name="Zigbee binding" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Output" />
     </Unit>
   </Device>
 

--- a/src/OpenNetty/OpenNettyEndpoint.cs
+++ b/src/OpenNetty/OpenNettyEndpoint.cs
@@ -28,6 +28,11 @@ public sealed class OpenNettyEndpoint : IEquatable<OpenNettyEndpoint>
     public ImmutableHashSet<OpenNettyCapability> Capabilities { get; init; } = [];
 
     /// <summary>
+    /// Gets or sets the description associated with the endpoint, if applicable.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
     /// Gets or sets the device associated with the endpoint, if applicable.
     /// </summary>
     public OpenNettyDevice? Device { get; init; }
@@ -47,9 +52,9 @@ public sealed class OpenNettyEndpoint : IEquatable<OpenNettyEndpoint>
     public OpenNettyMedium? Medium { get; init; }
 
     /// <summary>
-    /// Gets or sets the optional name associated with the endpoint.
+    /// Gets or sets the name associated with the endpoint.
     /// </summary>
-    public string? Name { get; init; }
+    public required string Name { get; init; }
 
     /// <summary>
     /// Gets or sets the protocol associated with the endpoint.
@@ -96,12 +101,12 @@ public sealed class OpenNettyEndpoint : IEquatable<OpenNettyEndpoint>
     {
         if (Protocol is OpenNettyProtocol.Nitoo or OpenNettyProtocol.Zigbee && Unit is OpenNettyUnit unit)
         {
-            return unit.Definition.HasCapability(capability);
+            return unit.HasCapability(capability);
         }
 
         if (Device is OpenNettyDevice device)
         {
-            return device.Definition.HasCapability(capability);
+            return device.HasCapability(capability);
         }
 
         return Capabilities.Contains(capability);
@@ -116,21 +121,22 @@ public sealed class OpenNettyEndpoint : IEquatable<OpenNettyEndpoint>
     /// <returns><see langword="true"/> if the setting was found, <see langword="false"/> otherwise.</returns>
     public bool TryGetSetting(OpenNettySetting setting, [NotNullWhen(true)] out string? value)
     {
-        if (Protocol is OpenNettyProtocol.Nitoo or OpenNettyProtocol.Zigbee && Unit is OpenNettyUnit unit)
+        if (Settings.TryGetValue(setting, out value))
         {
-            return unit.Settings.TryGetValue(setting, out value) ||
-                unit.Definition.Settings.TryGetValue(setting, out value) ||
-                Settings.TryGetValue(setting, out value);
+            return true;
         }
 
-        else if (Device is OpenNettyDevice device)
+        return Protocol switch
         {
-            return device.Settings.TryGetValue(setting, out value) ||
-                device.Definition.Settings.TryGetValue(setting, out value) ||
-                Settings.TryGetValue(setting, out value);
-        }
+            OpenNettyProtocol.Nitoo or OpenNettyProtocol.Zigbee when Unit is OpenNettyUnit unit
+                => unit.TryGetSetting(setting, out value),
 
-        return Settings.TryGetValue(setting, out value);
+            OpenNettyProtocol.Nitoo or OpenNettyProtocol.Scs or
+            OpenNettyProtocol.Zigbee when Device is OpenNettyDevice device
+                => device.TryGetSetting(setting, out value),
+
+            _ => false
+        };
     }
 
     /// <inheritdoc/>
@@ -157,6 +163,11 @@ public sealed class OpenNettyEndpoint : IEquatable<OpenNettyEndpoint>
         }
 
         if (Device != other.Device)
+        {
+            return false;
+        }
+
+        if (!string.Equals(Description, other.Description, StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }
@@ -204,6 +215,7 @@ public sealed class OpenNettyEndpoint : IEquatable<OpenNettyEndpoint>
             hash.Add(capability);
         }
 
+        hash.Add(Description);
         hash.Add(Device);
         hash.Add(Medium);
         hash.Add(Name);

--- a/src/OpenNetty/OpenNettyEvents.cs
+++ b/src/OpenNetty/OpenNettyEvents.cs
@@ -77,13 +77,25 @@ public sealed class OpenNettyEvents : IDisposable
         => _observable.OfType<EventArgs, BasicScenarioReportedEventArgs>();
 
     /// <summary>
+    /// Gets an event triggered when a battery alert is reported.
+    /// </summary>
+    public IAsyncObservable<BatteryAlertReportedEventArgs> BatteryAlertReported
+        => _observable.OfType<EventArgs, BatteryAlertReportedEventArgs>();
+
+    /// <summary>
     /// Gets an event triggered when a battery level is reported.
     /// </summary>
     public IAsyncObservable<BatteryLevelReportedEventArgs> BatteryLevelReported
         => _observable.OfType<EventArgs, BatteryLevelReportedEventArgs>();
 
     /// <summary>
-    /// Gets an event triggered when a binding is closed is reported.
+    /// Gets an event triggered when a binding is canceled.
+    /// </summary>
+    public IAsyncObservable<BindingCanceledEventArgs> BindingCanceled
+        => _observable.OfType<EventArgs, BindingCanceledEventArgs>();
+
+    /// <summary>
+    /// Gets an event triggered when a binding is closed.
     /// </summary>
     public IAsyncObservable<BindingClosedEventArgs> BindingClosed
         => _observable.OfType<EventArgs, BindingClosedEventArgs>();
@@ -209,6 +221,12 @@ public sealed class OpenNettyEvents : IDisposable
         => _observable.OfType<EventArgs, ToggleScenarioReportedEventArgs>();
 
     /// <summary>
+    /// Gets an event triggered when an uptime duration is reported.
+    /// </summary>
+    public IAsyncObservable<UptimeReportedEventArgs> UptimeReported
+        => _observable.OfType<EventArgs, UptimeReportedEventArgs>();
+
+    /// <summary>
     /// Gets an event triggered when a water heater setpoint mode is reported.
     /// </summary>
     public IAsyncObservable<WaterHeaterSetpointModeReportedEventArgs> WaterHeaterSetpointModeReported
@@ -264,11 +282,23 @@ public sealed class OpenNettyEvents : IDisposable
     public sealed record class BasicScenarioReportedEventArgs(OpenNettyEndpoint Endpoint) : EventArgs(Endpoint);
 
     /// <summary>
+    /// Represents event arguments used when a battery alert is reported.
+    /// </summary>
+    /// <param name="Endpoint">The endpoint.</param>
+    public sealed record class BatteryAlertReportedEventArgs(OpenNettyEndpoint Endpoint) : EventArgs(Endpoint);
+
+    /// <summary>
     /// Represents event arguments used when a battery level is reported.
     /// </summary>
     /// <param name="Endpoint">The endpoint.</param>
     /// <param name="Level">The battery level.</param>
     public sealed record class BatteryLevelReportedEventArgs(OpenNettyEndpoint Endpoint, byte Level) : EventArgs(Endpoint);
+
+    /// <summary>
+    /// Represents event arguments used when a binding is canceled.
+    /// </summary>
+    /// <param name="Endpoint">The endpoint.</param>
+    public sealed record class BindingCanceledEventArgs(OpenNettyEndpoint Endpoint) : EventArgs(Endpoint);
 
     /// <summary>
     /// Represents event arguments used when a binding is closed.
@@ -418,6 +448,13 @@ public sealed class OpenNettyEvents : IDisposable
     /// </summary>
     /// <param name="Endpoint">The endpoint.</param>
     public sealed record class ToggleScenarioReportedEventArgs(OpenNettyEndpoint Endpoint) : EventArgs(Endpoint);
+
+    /// <summary>
+    /// Represents event arguments used when an uptime duration is reported.
+    /// </summary>
+    /// <param name="Endpoint">The endpoint.</param>
+    /// <param name="Duration">The uptime duration.</param>
+    public sealed record class UptimeReportedEventArgs(OpenNettyEndpoint Endpoint, TimeSpan Duration) : EventArgs(Endpoint);
 
     /// <summary>
     /// Represents event arguments used when a water heater setpoint mode is reported.

--- a/src/OpenNetty/OpenNettyIdentity.cs
+++ b/src/OpenNetty/OpenNettyIdentity.cs
@@ -23,26 +23,32 @@ public readonly struct OpenNettyIdentity : IEquatable<OpenNettyIdentity>
     public required string? Collection { get; init; }
 
     /// <summary>
-    /// Gets or sets the model.
+    /// Gets or sets the description.
+    /// </summary>
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// Gets or sets the product code.
     /// </summary>
     public required string Model { get; init; }
 
     /// <inheritdoc/>
     public bool Equals(OpenNettyIdentity other) => Brand == other.Brand &&
         string.Equals(Collection, other.Collection, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(Description, other.Description, StringComparison.OrdinalIgnoreCase) &&
         string.Equals(Model, other.Model, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is OpenNettyIdentity identity && Equals(identity);
 
     /// <inheritdoc/>
-    public override int GetHashCode() => HashCode.Combine(Brand, Collection, Model);
+    public override int GetHashCode() => HashCode.Combine(Brand, Collection, Description, Model);
 
     /// <summary>
     /// Computes the <see cref="string"/> representation of the current identity.
     /// </summary>
     /// <returns>The <see cref="string"/> representation of the current identity.</returns>
-    public override string ToString() => $"{Enum.GetName(Brand)} {Collection} {Model}";
+    public override string ToString() => $"{Enum.GetName(Brand)} {Collection} {Description} ({Model})";
 
     /// <summary>
     /// Determines whether two <see cref="OpenNettyIdentity"/> instances are equal.

--- a/src/OpenNetty/OpenNettyManager.cs
+++ b/src/OpenNetty/OpenNettyManager.cs
@@ -24,6 +24,22 @@ public class OpenNettyManager
         => _options = options ?? throw new ArgumentNullException(nameof(options));
 
     /// <summary>
+    /// Iterates all the devices registered in the options.
+    /// </summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// An <see cref="IAsyncEnumerable{T}"/> that can be used to iterate the devices registered in the options.
+    /// </returns>
+    public virtual async IAsyncEnumerable<OpenNettyDevice> EnumerateDevicesAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (var device in _options.CurrentValue.Devices.ToAsyncEnumerable())
+        {
+            yield return device;
+        }
+    }
+
+    /// <summary>
     /// Iterates all the endpoints registered in the options.
     /// </summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
@@ -85,8 +101,8 @@ public class OpenNettyManager
             {
                 if (endpoint is not null)
                 {
-                    return ValueTask.FromException<OpenNettyEndpoint?>(new InvalidOperationException(
-                        "Multiple endpoints matching the specified endpoint name exist."));
+                    return ValueTask.FromException<OpenNettyEndpoint?>(
+                        new InvalidOperationException(SR.GetResourceString(SR.ID0116)));
                 }
 
                 endpoint = _options.CurrentValue.Endpoints[index];
@@ -123,8 +139,8 @@ public class OpenNettyManager
             {
                 if (endpoint is not null)
                 {
-                    return ValueTask.FromException<OpenNettyEndpoint?>(new InvalidOperationException(
-                        "Multiple endpoints matching the specified predicate exist."));
+                    return ValueTask.FromException<OpenNettyEndpoint?>(
+                        new InvalidOperationException(SR.GetResourceString(SR.ID0116)));
                 }
 
                 endpoint = _options.CurrentValue.Endpoints[index];
@@ -159,8 +175,8 @@ public class OpenNettyManager
             {
                 if (endpoint is not null)
                 {
-                    return ValueTask.FromException<OpenNettyEndpoint?>(new InvalidOperationException(
-                        "Multiple endpoints matching the specified address exist."));
+                    return ValueTask.FromException<OpenNettyEndpoint?>(
+                        new InvalidOperationException(SR.GetResourceString(SR.ID0116)));
                 }
 
                 endpoint = _options.CurrentValue.Endpoints[index];
@@ -333,8 +349,8 @@ public class OpenNettyManager
             {
                 if (gateway is not null)
                 {
-                    return ValueTask.FromException<OpenNettyGateway?>(new InvalidOperationException(
-                        "Multiple gateways matching the specified address exist."));
+                    return ValueTask.FromException<OpenNettyGateway?>(
+                        new InvalidOperationException(SR.GetResourceString(SR.ID0116)));
                 }
 
                 gateway = _options.CurrentValue.Gateways[index];

--- a/src/OpenNetty/OpenNettyResources.resx
+++ b/src/OpenNetty/OpenNettyResources.resx
@@ -462,6 +462,18 @@
   <data name="ID0115" xml:space="preserve">
     <value>A device with the serial number '{0}' has already been added.</value>
   </data>
+  <data name="ID0116" xml:space="preserve">
+    <value>Multiple endpoints matching the specified criteria were found.</value>
+  </data>
+  <data name="ID0117" xml:space="preserve">
+    <value>Multiple gateways matching the specified criteria were found.</value>
+  </data>
+  <data name="ID0118" xml:space="preserve">
+    <value>An endpoint name must be explicitly attached to Nitoo and Zigbee endpoints whose device doesn't have a serial number set.</value>
+  </data>
+  <data name="ID0119" xml:space="preserve">
+    <value>An endpoint name must be explicitly attached to SCS light point endpoints.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The endpoint name '{0}' is not valid. Endpoint names cannot contain the '+' or '*' characters.</value>
   </data>
@@ -476,6 +488,21 @@
   </data>
   <data name="ID2004" xml:space="preserve">
     <value>The endpoint '{0}' doesn't have a valid switch mode setting attached ({1}). Only 'Default' and 'Push button' are currently supported.</value>
+  </data>
+  <data name="ID2005" xml:space="preserve">
+    <value>The MQTT topic '{0}' is not valid. Topics cannot contain the '+' or '*' characters.</value>
+  </data>
+  <data name="ID2006" xml:space="preserve">
+    <value>The serial number '{0}' isn't valid. Serial numbers can only contains decimal or hexadecimal representations.</value>
+  </data>
+  <data name="ID2007" xml:space="preserve">
+    <value>The MQTT root topic cannot end with a '/' character.</value>
+  </data>
+  <data name="ID2008" xml:space="preserve">
+    <value>The Home Assistant discovery topic cannot end with a '/' character.</value>
+  </data>
+  <data name="ID2009" xml:space="preserve">
+    <value>The MQTT root and Home Assistant discovery topics cannot be set to the same value.</value>
   </data>
   <data name="ID6000" xml:space="preserve">
     <value>The OpenNetty hosted service is starting.</value>

--- a/src/OpenNetty/OpenNettySettings.cs
+++ b/src/OpenNetty/OpenNettySettings.cs
@@ -22,9 +22,24 @@ public static class OpenNettySettings
     public static readonly OpenNettySetting ActuatorType = new("Actuator type");
 
     /// <summary>
-    /// Home Assistant device class.
+    /// Home Assistant light/switch device class.
     /// </summary>
-    public static readonly OpenNettySetting HomeAssistantDeviceClass = new("Home Assistant device class");
+    public static readonly OpenNettySetting HomeAssistantCoverDeviceClass = new("Home Assistant cover device class");
+
+    /// <summary>
+    /// Home Assistant light/switch icon.
+    /// </summary>
+    public static readonly OpenNettySetting HomeAssistantCoverIcon = new("Home Assistant cover icon");
+
+    /// <summary>
+    /// Home Assistant light/switch name.
+    /// </summary>
+    public static readonly OpenNettySetting HomeAssistantCoverName = new("Home Assistant cover name");
+
+    /// <summary>
+    /// Home Assistant discovery.
+    /// </summary>
+    public static readonly OpenNettySetting HomeAssistantDiscovery = new("Home Assistant discovery");
 
     /// <summary>
     /// Home Assistant entity type.
@@ -32,19 +47,44 @@ public static class OpenNettySettings
     public static readonly OpenNettySetting HomeAssistantEntityType = new("Home Assistant entity type");
 
     /// <summary>
+    /// Home Assistant light/switch device class.
+    /// </summary>
+    public static readonly OpenNettySetting HomeAssistantLightSwitchDeviceClass = new("Home Assistant light/switch device class");
+
+    /// <summary>
+    /// Home Assistant light/switch icon.
+    /// </summary>
+    public static readonly OpenNettySetting HomeAssistantLightSwitchIcon = new("Home Assistant light/switch icon");
+
+    /// <summary>
+    /// Home Assistant light/switch name.
+    /// </summary>
+    public static readonly OpenNettySetting HomeAssistantLightSwitchName = new("Home Assistant light/switch name");
+
+    /// <summary>
+    /// Home Assistant scenario device class.
+    /// </summary>
+    public static readonly OpenNettySetting HomeAssistantScenarioDeviceClass = new("Home Assistant scenario device class");
+
+    /// <summary>
+    /// Home Assistant scenario icon.
+    /// </summary>
+    public static readonly OpenNettySetting HomeAssistantScenarioIcon = new("Home Assistant scenario icon");
+
+    /// <summary>
+    /// Home Assistant scenario name.
+    /// </summary>
+    public static readonly OpenNettySetting HomeAssistantScenarioName = new("Home Assistant scenario name");
+
+    /// <summary>
     /// Home Assistant suggested area.
     /// </summary>
     public static readonly OpenNettySetting HomeAssistantSuggestedArea = new("Home Assistant suggested area");
 
     /// <summary>
-    /// MQTT discovery.
+    /// MQTT topic.
     /// </summary>
-    public static readonly OpenNettySetting MqttDiscovery = new("MQTT discovery");
-
-    /// <summary>
-    /// MQTT endpoint name.
-    /// </summary>
-    public static readonly OpenNettySetting MqttEndpointName = new("MQTT endpoint name");
+    public static readonly OpenNettySetting MqttTopic = new("MQTT topic");
 
     /// <summary>
     /// Serial port baud rate.

--- a/src/OpenNetty/OpenNettyUnit.cs
+++ b/src/OpenNetty/OpenNettyUnit.cs
@@ -46,13 +46,22 @@ public sealed class OpenNettyUnit : IEquatable<OpenNettyUnit>
     public string? GetStringSetting(OpenNettySetting setting) => TryGetSetting(setting, out string? value) ? value : null;
 
     /// <summary>
+    /// Determines whether the unit has the specified capability.
+    /// </summary>
+    /// <param name="capability">The capability name.</param>
+    /// <returns>
+    /// <see langword="true"/> if the unit has the specified capability, <see langword="false"/> otherwise.
+    /// </returns>
+    public bool HasCapability(OpenNettyCapability capability) => Definition.HasCapability(capability);
+
+    /// <summary>
     /// Tries to resolve the specified setting from the settings.
     /// </summary>
     /// <param name="setting">The setting name.</param>
     /// <param name="value">The setting value, or <see langword="null"/> if it was not found.</param>
     /// <returns><see langword="true"/> if the setting was found, <see langword="false"/> otherwise.</returns>
     public bool TryGetSetting(OpenNettySetting setting, [NotNullWhen(true)] out string? value)
-        => Settings.TryGetValue(setting, out value);
+        => Settings.TryGetValue(setting, out value) || Definition.Settings.TryGetValue(setting, out value);
 
     /// <inheritdoc/>
     public bool Equals(OpenNettyUnit? other)

--- a/src/OpenNetty/OpenNettyUnitDefinition.cs
+++ b/src/OpenNetty/OpenNettyUnitDefinition.cs
@@ -19,6 +19,11 @@ public sealed class OpenNettyUnitDefinition : IEquatable<OpenNettyUnitDefinition
     public byte? AssociatedUnitId { get; init; }
 
     /// <summary>
+    /// Gets or sets the description associated with the unit definition.
+    /// </summary>
+    public required string Description { get; init; }
+
+    /// <summary>
     /// Gets or sets the capabilities associated with the unit definition.
     /// </summary>
     public required ImmutableHashSet<OpenNettyCapability> Capabilities { get; init; } = [];
@@ -45,6 +50,7 @@ public sealed class OpenNettyUnitDefinition : IEquatable<OpenNettyUnitDefinition
         return other is not null &&
             AssociatedUnitId == other.AssociatedUnitId &&
             Capabilities.Count == other.Capabilities.Count && Capabilities.Except(other.Capabilities).IsEmpty &&
+            string.Equals(Description, other.Description, StringComparison.OrdinalIgnoreCase) &&
             Id == other.Id &&
             Settings.Count == other.Settings.Count && !Settings.Except(other.Settings).Any();
     }
@@ -64,6 +70,7 @@ public sealed class OpenNettyUnitDefinition : IEquatable<OpenNettyUnitDefinition
             hash.Add(capability);
         }
 
+        hash.Add(Description);
         hash.Add(Id);
 
         hash.Add(Settings.Count);


### PR DESCRIPTION
This PR introduces a lot of improvements to MQTT discovery by introducing new nodes in device definitions that allow identifying In One/MyHome/MyHome Play products much more easily and by adding a lot of new sensors and buttons for the supported features. This should make MQTT discovery good enough to treat it as the recommended option for integrating with OpenNetty's MQTT bridge.

Here's an example with a Legrand 67223 wireless switch:

<img width="1055" height="873" alt="image" src="https://github.com/user-attachments/assets/73f5c6b5-81e9-4ea7-a113-0e938777fb23" />
