### PR TITLE
Add units/modules support for SCS devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The following Legrand and BTicino products are partially or fully supported by O
 | MyHome Up         |                    | 03651             | F418U2            | 2-gang DIN rail dimmer switch          |
 | MyHome Up         |                    | 03847             | F411U1            | 1-gang DIN rail switch                 |
 | MyHome Up         |                    | 03848             | F411U2            | 2-gang DIN rail switch                 |
-| MyHome Up         | Céliane            | 67557             |                   | 2-channel advanced automation actuator |
+| MyHome Up         | Céliane            | 67557             |                   | 1-channel advanced automation actuator |
 | MyHome Up         | Céliane            | 67561             |                   | 2-channel lighting/automation actuator |
 |                   |                    |                   |                   |                                        |
 | MyHome Play       | Céliane            | 67223             |                   | Light control switch                   |
@@ -246,7 +246,8 @@ To be able to communicate with "In One by Legrand", "MyHome Play" and "MyHome Up
 
 For that, you need to add a `Device` node with the correct brand/model attributes for each device present in the installation:
   - The serial number is required for In One by Legrand and MyHome Play devices and optional for MyHome Up devices.
-  - The unit node is not used for MyHome Up devices but is generally required for In One by Legrand and MyHome Play devices.
+  - The unit node - also known as a "module" in MyHome Suite - is generally required,
+  except when targeting a feature exposed by the device itself and not one of its units.
   - The unit must match one of the unit identifiers offered by the specific device. If you're unsure what identifier should be used,
   you can see [`OpenNettyDevices.xml`](src/OpenNetty/OpenNettyDevices.xml) for a list of all the supported devices and the units they expose.
   - For MyHome Up devices, the area/point attributes must match the values assigned via [MyHome Suite](https://www.homesystems-legrandgroup.com/home?p_p_id=it_smc_bticino_homesystems_search_AutocompletesearchPortlet&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_it_smc_bticino_homesystems_search_AutocompletesearchPortlet_journalArticleId=2493426&_it_smc_bticino_homesystems_search_AutocompletesearchPortlet_mvcPath=%2Fview_journal_article_content.jsp).
@@ -316,28 +317,39 @@ For that, you need to add a `Device` node with the correct brand/model attribute
   <!-- MyHome Up two-way light actuator -->
 
   <Device Brand="BTicino" Model="F411U2" SerialNumber="00B582A5">
-    <Endpoint Name="Garage/Recessed light 1" Type="SCS light point" Area="4" Point="1">
-      <Setting Name="Actuator type" Value="Lighting" />
-    </Endpoint>
+    <Unit Id="1">
+      <Endpoint Name="Garage/Recessed light 1" Area="4" Point="1">
+        <Setting Name="Actuator type" Value="Lighting" />
+      </Endpoint>
+    </Unit>
 
-    <Endpoint Name="Garage/Recessed light 2" Type="SCS light point" Area="4" Point="2">
-      <Setting Name="Actuator type" Value="Lighting" />
-    </Endpoint>
+    <Unit Id="2">
+      <Endpoint Name="Garage/Recessed light 2" Area="4" Point="2">
+        <Setting Name="Actuator type" Value="Lighting" />
+      </Endpoint>
+    </Unit>
   </Device>
 
   <!-- MyHome Up shutter actuator -->
 
   <Device Brand="BTicino" Model="F411U2" SerialNumber="00A472A9">
-    <Endpoint Name="Living room/Shutter" Type="SCS light point" Area="1" Point="3">
-      <Setting Name="Actuator type" Value="Automation" />
-    </Endpoint>
+    <Unit Id="1">
+      <Endpoint Name="Living room/Shutter" Area="1" Point="3">
+        <Setting Name="Actuator type" Value="Automation" />
+      </Endpoint>
+    </Unit>
   </Device>
 
   <!-- MyHome Up two-way dimmer -->
 
   <Device Brand="BTicino" Model="F418U2" SerialNumber="00B582A5">
-    <Endpoint Name="Living room/Wall light 1" Type="SCS light point" Area="1" Point="1" />
-    <Endpoint Name="Living room/Wall light 2" Type="SCS light point" Area="1" Point="2" />
+    <Unit Id="1">
+      <Endpoint Name="Living room/Wall light 1" Area="1" Point="1" />
+    </Unit>
+
+    <Unit Id="2">
+      <Endpoint Name="Living room/Wall light 2" Area="1" Point="2" />
+    </Unit>
   </Device>
 
   <!-- MyHome Up light point group endpoint -->
@@ -575,7 +587,19 @@ builder.Services.AddOpenNetty(options =>
         Device = new OpenNettyDevice
         {
             Definition = OpenNettyDevices.GetDeviceByModel(OpenNettyBrand.BTicino, "F418U2")
-                ?? throw new InvalidOperationException("The specified gateway model is not supported.")
+                ?? throw new InvalidOperationException("The specified product is not supported."),
+            Identity = new OpenNettyIdentity
+            {
+                Brand = OpenNettyBrand.BTicino,
+                Collection = null,
+                Description = "2-gang DIN rail dimmer switch",
+                Model = "F418U2"
+            }
+        },
+        Unit = new OpenNettyUnit
+        {
+            Definition = OpenNettyDevices.GetUnitByModel(OpenNettyBrand.BTicino, "F418U2", 1)
+                ?? throw new InvalidOperationException("The specified product is not supported.")
         },
         Name = "Bathroom/Recessed light",
         Protocol = OpenNettyProtocol.Scs
@@ -680,6 +704,7 @@ options.AddEndpoint(new OpenNettyEndpoint
         {
             Brand = OpenNettyBrand.Legrand,
             Collection = "Céliane",
+            Description = "Dimmable switched outlet",
             Model = "67222"
         },
         SerialNumber = "487932",
@@ -702,15 +727,19 @@ To avoid ambiguities, OpenNetty requires that the actual type be specified for S
 
 ```xml
 <Device Brand="BTicino" Model="F411U2" SerialNumber="00B582A5">
-  <Endpoint Name="Garage/Recessed light 1" Type="SCS light point" Area="4" Point="1">
-    <Setting Name="Actuator type" Value="Lighting" />
-  </Endpoint>
+  <Unit Id="1">
+    <Endpoint Name="Garage/Recessed light 1" Area="4" Point="1">
+      <Setting Name="Actuator type" Value="Lighting" />
+    </Endpoint>
+  </Unit>
 </Device>
 
 <Device Brand="BTicino" Model="F411U2" SerialNumber="00A472A9">
-  <Endpoint Name="Living room/Shutter" Type="SCS light point" Area="1" Point="3">
-    <Setting Name="Actuator type" Value="Automation" />
-  </Endpoint>
+  <Unit Id="1">
+    <Endpoint Name="Living room/Shutter" Area="1" Point="3">
+      <Setting Name="Actuator type" Value="Automation" />
+    </Endpoint>
+  </Unit>
 </Device>
 ```
 
@@ -748,9 +777,11 @@ switch mode so that OpenNetty can properly report the OFF state and ignore area 
 
 ```xml
 <Device Brand="BTicino" Model="F411U1" SerialNumber="0019BF87">
-  <Endpoint Name="Patio/Doorbell" Type="SCS light point" Area="9" Point="1">
-    <Setting Name="Switch mode" Value="Push button" />
-  </Endpoint>
+  <Unit Id="1">
+    <Endpoint Name="Patio/Doorbell" Area="9" Point="1">
+      <Setting Name="Switch mode" Value="Push button" />
+    </Endpoint>
+  </Unit>
 </Device>
 ```
 

--- a/src/OpenNetty/OpenNettyBuilder.cs
+++ b/src/OpenNetty/OpenNettyBuilder.cs
@@ -325,7 +325,13 @@ public sealed class OpenNettyBuilder
                 OpenNettyProtocol.Nitoo  => OpenNettyAddressType.Nitoo,
                 OpenNettyProtocol.Zigbee => OpenNettyAddressType.Zigbee,
 
-                // Note: SCS addresses are never inferred automatically and a type MUST be explicitly attached.
+                // Note: SCS units/modules supporting ON/OFF switching or shutter
+                // control are assumed to use SCS light point addresses by default.
+                OpenNettyProtocol.Scs when unit is not null &&
+                    (unit.Definition.Capabilities.Contains(OpenNettyCapabilities.OnOffSwitchControl) ||
+                     unit.Definition.Capabilities.Contains(OpenNettyCapabilities.BasicShutterControl) ||
+                     unit.Definition.Capabilities.Contains(OpenNettyCapabilities.AdvancedShutterControl))
+                    => OpenNettyAddressType.ScsLightPoint,
 
                 _ => throw new InvalidOperationException(SR.FormatID0088(name, "Type"))
             };

--- a/src/OpenNetty/OpenNettyDevice.cs
+++ b/src/OpenNetty/OpenNettyDevice.cs
@@ -37,7 +37,7 @@ public sealed class OpenNettyDevice : IEquatable<OpenNettyDevice>
         ImmutableDictionary<OpenNettySetting, string>.Empty;
 
     /// <summary>
-    /// Gets or sets the units associated with the device, if applicable.
+    /// Gets or sets the units associated with the device.
     /// </summary>
     public ImmutableArray<OpenNettyUnit> Units { get; init; } = [];
 

--- a/src/OpenNetty/OpenNettyDevices.xml
+++ b/src/OpenNetty/OpenNettyDevices.xml
@@ -808,30 +808,61 @@
     <Identity Brand="BTicino" Model="F411U1" Description="1-gang DIN rail switch" />
     <Identity Brand="Legrand" Model="03847"  Description="1-gang DIN rail switch" />
 
-    <Capability Name="On/off switch state" />
-    <Capability Name="On/off switch control" />
+    <Unit Id="1" Description="Output">
+      <Capability Name="On/off switch state" />
+      <Capability Name="On/off switch control" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Module 1" />
+    </Unit>
   </Device>
 
   <Device Series="MyHome" Protocol="Scs" Medium="Bus">
     <Identity Brand="BTicino" Model="F411U2" Description="2-gang DIN rail switch" />
     <Identity Brand="Legrand" Model="03848"  Description="2-gang DIN rail switch" />
 
-    <Capability Name="Basic shutter control" />
-    <Capability Name="Basic shutter state" />
-    <Capability Name="On/off switch state" />
-    <Capability Name="On/off switch control" />
+    <Unit Id="1" Description="Output 1">
+      <Capability Name="Basic shutter control" />
+      <Capability Name="Basic shutter state" />
+      <Capability Name="On/off switch state" />
+      <Capability Name="On/off switch control" />
+
+      <Setting Name="Home Assistant cover name" Value="Module 1" />
+      <Setting Name="Home Assistant light/switch name" Value="Module 1" />
+    </Unit>
+
+    <Unit Id="2" Description="Output 2">
+      <Capability Name="On/off switch state" />
+      <Capability Name="On/off switch control" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Module 2" />
+    </Unit>
   </Device>
 
   <Device Series="MyHome" Protocol="Scs" Medium="Bus">
     <Identity Brand="BTicino" Model="F418U2" Description="2-gang DIN rail dimmer switch" />
     <Identity Brand="Legrand" Model="03651"  Description="2-gang DIN rail dimmer switch" />
 
-    <Capability Name="Advanced dimming control" />
-    <Capability Name="Advanced dimming state" />
-    <Capability Name="Basic dimming control" />
-    <Capability Name="Basic dimming state" />
-    <Capability Name="On/off switch state" />
-    <Capability Name="On/off switch control" />
+    <Unit Id="1" Description="Output 1">
+      <Capability Name="Advanced dimming control" />
+      <Capability Name="Advanced dimming state" />
+      <Capability Name="Basic dimming control" />
+      <Capability Name="Basic dimming state" />
+      <Capability Name="On/off switch state" />
+      <Capability Name="On/off switch control" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Module 1" />
+    </Unit>
+
+    <Unit Id="2" Description="Output 2">
+      <Capability Name="Advanced dimming control" />
+      <Capability Name="Advanced dimming state" />
+      <Capability Name="Basic dimming control" />
+      <Capability Name="Basic dimming state" />
+      <Capability Name="On/off switch state" />
+      <Capability Name="On/off switch control" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Module 2" />
+    </Unit>
   </Device>
 
   <Device Series="MyHome" Protocol="Scs" Medium="Bus">
@@ -859,21 +890,40 @@
   </Device>
 
   <Device Series="MyHome" Protocol="Scs" Medium="Bus">
-    <Identity Brand="Legrand" Collection="Céliane" Model="67557" Description="2-channel advanced automation actuator" />
+    <Identity Brand="Legrand" Collection="Céliane" Model="67557" Description="1-channel advanced automation actuator" />
 
-    <Capability Name="Advanced shutter control" />
-    <Capability Name="Advanced shutter state" />
-    <Capability Name="Basic shutter control" />
-    <Capability Name="Basic shutter state" />
+    <Unit Id="1" Description="Output 1">
+      <Capability Name="Advanced shutter control" />
+      <Capability Name="Advanced shutter state" />
+      <Capability Name="Basic shutter control" />
+      <Capability Name="Basic shutter state" />
+
+      <Setting Name="Home Assistant cover name" Value="Module 1" />
+    </Unit>
   </Device>
 
   <Device Series="MyHome" Protocol="Scs" Medium="Bus">
     <Identity Brand="Legrand" Collection="Céliane" Model="67561" Description="2-channel lighting/automation actuator" />
 
-    <Capability Name="Basic shutter control" />
-    <Capability Name="Basic shutter state" />
-    <Capability Name="On/off switch state" />
-    <Capability Name="On/off switch control" />
+    <Unit Id="1" Description="Output 1">
+      <Capability Name="Basic shutter control" />
+      <Capability Name="Basic shutter state" />
+      <Capability Name="On/off switch state" />
+      <Capability Name="On/off switch control" />
+
+      <Setting Name="Home Assistant cover name" Value="Module 1" />
+      <Setting Name="Home Assistant light/switch name" Value="Module 1" />
+    </Unit>
+
+    <Unit Id="2" Description="Output 2">
+      <Capability Name="On/off switch state" />
+      <Capability Name="On/off switch control" />
+
+      <Setting Name="Home Assistant light/switch name" Value="Module 2" />
+    </Unit>
+
+    <Unit Id="3" Description="Command 1" />
+    <Unit Id="4" Description="Command 2" />
   </Device>
 
   <!--

--- a/src/OpenNetty/OpenNettyEndpoint.cs
+++ b/src/OpenNetty/OpenNettyEndpoint.cs
@@ -70,7 +70,6 @@ public sealed class OpenNettyEndpoint : IEquatable<OpenNettyEndpoint>
     /// <summary>
     /// Gets or sets the unit associated with the endpoint, if applicable.
     /// </summary>
-    /// <remarks>Note: units are only valid for Nitoo or Zigbee endpoints.</remarks>
     public OpenNettyUnit? Unit { get; init; }
 
     /// <summary>
@@ -99,7 +98,7 @@ public sealed class OpenNettyEndpoint : IEquatable<OpenNettyEndpoint>
     /// </returns>
     public bool HasCapability(OpenNettyCapability capability)
     {
-        if (Protocol is OpenNettyProtocol.Nitoo or OpenNettyProtocol.Zigbee && Unit is OpenNettyUnit unit)
+        if (Unit is OpenNettyUnit unit)
         {
             return unit.HasCapability(capability);
         }
@@ -126,17 +125,17 @@ public sealed class OpenNettyEndpoint : IEquatable<OpenNettyEndpoint>
             return true;
         }
 
-        return Protocol switch
+        if (Unit is OpenNettyUnit unit)
         {
-            OpenNettyProtocol.Nitoo or OpenNettyProtocol.Zigbee when Unit is OpenNettyUnit unit
-                => unit.TryGetSetting(setting, out value),
+            return unit.TryGetSetting(setting, out value);
+        }
 
-            OpenNettyProtocol.Nitoo or OpenNettyProtocol.Scs or
-            OpenNettyProtocol.Zigbee when Device is OpenNettyDevice device
-                => device.TryGetSetting(setting, out value),
+        if (Device is OpenNettyDevice device)
+        {
+            return device.TryGetSetting(setting, out value);
+        }
 
-            _ => false
-        };
+        return false;
     }
 
     /// <inheritdoc/>

--- a/src/OpenNetty/OpenNettyUnit.cs
+++ b/src/OpenNetty/OpenNettyUnit.cs
@@ -20,7 +20,7 @@ public sealed class OpenNettyUnit : IEquatable<OpenNettyUnit>
     public required OpenNettyUnitDefinition Definition { get; init; }
 
     /// <summary>
-    /// Gets or sets the scenarios associated with the unit, if applicable.
+    /// Gets or sets the scenarios associated with the unit, if applicable (Nitoo-only).
     /// </summary>
     public ImmutableArray<OpenNettyScenario> Scenarios { get; init; } = [];
 


### PR DESCRIPTION
This PR updates the devices database to use units - aka modules in MyHome Suite - for all the supported SCS devices. Doing that makes SCS devices more consistent with Nitoo and Zigbee devices (tho' the unit ID is not used to determine the address, unlike in the Nitoo and Zigbee specifications) and allows much more granular capability checks.