### PR TITLE
Revamp transmission options, add Zigbee network management support and use outgoing frames to detect state changes affecting Zigbee devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,12 +568,14 @@ var builder = Host.CreateApplicationBuilder();
 
 builder.Services.AddOpenNetty(options =>
 {
-    options.AddGateway(OpenNettyGateway.Create(
+    var gateway = OpenNettyGateway.Create(
         name    : "F454 gateway",
         brand   : OpenNettyBrand.BTicino,
         model   : "F454",
         endpoint: IPEndPoint.Parse("192.168.5.10:20000"),
-        password: "aJhYiBHk8"));
+        password: "aJhYiBHk8");
+
+    options.AddGateway(gateway);
 
     options.AddEndpoint(new OpenNettyEndpoint
     {
@@ -596,6 +598,7 @@ builder.Services.AddOpenNetty(options =>
                 Model = "F418U2"
             }
         },
+        Gateway = gateway,
         Unit = new OpenNettyUnit
         {
             Definition = OpenNettyDevices.GetUnitByModel(OpenNettyBrand.BTicino, "F418U2", 1)
@@ -615,6 +618,7 @@ builder.Services.AddOpenNetty(options =>
             area     : 1,
             point    : null),
         Capabilities = [OpenNettyCapabilities.OnOffSwitchControl],
+        Gateway = gateway,
         Name = "Bathroom/All lights",
         Protocol = OpenNettyProtocol.Scs
     });
@@ -711,6 +715,7 @@ options.AddEndpoint(new OpenNettyEndpoint
         Settings = ImmutableDictionary.Create<OpenNettySetting, string>()
             .Add(OpenNettySettings.ActionValidation, bool.FalseString)
     },
+    Gateway = gateway,
     Name = "Kitchen/Dimmable socket",
     Protocol = OpenNettyProtocol.Nitoo,
     Unit = new OpenNettyUnit

--- a/src/OpenNetty.Mqtt/OpenNettyMqttAttributes.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttAttributes.cs
@@ -95,4 +95,14 @@ public static class OpenNettyMqttAttributes
     /// Zigbee binding.
     /// </summary>
     public const string ZigbeeBinding = "zigbee_binding";
+
+    /// <summary>
+    /// Zigbee network.
+    /// </summary>
+    public const string ZigbeeNetwork = "zigbee_network";
+
+    /// <summary>
+    /// Zigbee supervision.
+    /// </summary>
+    public const string ZigbeeSupervision = "zigbee_supervision";
 }

--- a/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
@@ -417,6 +417,44 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                                         break;
                                 }
                                 break;
+
+                            case OpenNettyMqttAttributes.ZigbeeNetwork when operation is OpenNettyMqttOperation.Set:
+                                switch (message.ConvertPayloadToString()?.ToLowerInvariant())
+                                {
+                                    case "close":
+                                        await _controller.CloseNetworkAsync(endpoint);
+                                        break;
+
+                                    case "create":
+                                        await _controller.CreateNetworkAsync(endpoint);
+                                        break;
+
+                                    case "join":
+                                        await _controller.JoinNetworkAsync(endpoint);
+                                        break;
+
+                                    case "leave":
+                                        await _controller.LeaveNetworkAsync(endpoint);
+                                        break;
+
+                                    case "open":
+                                        await _controller.OpenNetworkAsync(endpoint);
+                                        break;
+                                }
+                                break;
+
+                            case OpenNettyMqttAttributes.ZigbeeSupervision when operation is OpenNettyMqttOperation.Set:
+                                switch (message.ConvertPayloadToString()?.ToLowerInvariant())
+                                {
+                                    case "disable":
+                                        await _controller.DisableSupervisionAsync(endpoint);
+                                        break;
+
+                                    case "enable":
+                                        await _controller.EnableSupervisionAsync(endpoint);
+                                        break;
+                                }
+                                break;
                         }
 
                         if (!string.IsNullOrEmpty(message.ResponseTopic))
@@ -1539,6 +1577,131 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                                 .CountAsync(cancellationToken)),
                         ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ZigbeeBinding}/set",
                         ["payload_press"] = "unbind"
+                    });
+                }
+
+                if (endpoint.HasCapability(OpenNettyCapabilities.ZigbeeNetworkManagement))
+                {
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "f366a06c-6d7f-4741-a99a-490fedeabf9f"u8),
+                        ["icon"] = "mdi:new-box",
+                        ["name"] = ComputeEntityName(
+                            name    : "Create and open Zigbee network",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.ZigbeeNetworkManagement))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ZigbeeNetwork}/set",
+                        ["payload_press"] = "create"
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "1c56979a-3ad2-4b9b-9116-cd7321416b6a"u8),
+                        ["icon"] = "mdi:download-network",
+                        ["name"] = ComputeEntityName(
+                            name    : "Join Zigbee network",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.ZigbeeNetworkManagement))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ZigbeeNetwork}/set",
+                        ["payload_press"] = "join"
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "63096c5c-3fba-4ea7-a30d-3568b0680e18"u8),
+                        ["icon"] = "mdi:upload-network",
+                        ["name"] = ComputeEntityName(
+                            name    : "Leave Zigbee network",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.ZigbeeNetworkManagement))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ZigbeeNetwork}/set",
+                        ["payload_press"] = "leave"
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "09953b7d-0e18-4fc9-9b8c-2a11b52a15c5"u8),
+                        ["icon"] = "mdi:lock-open",
+                        ["name"] = ComputeEntityName(
+                            name    : "Open Zigbee network",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.ZigbeeNetworkManagement))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ZigbeeNetwork}/set",
+                        ["payload_press"] = "open"
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "7e344b36-199e-4a43-987f-59fccacc859b"u8),
+                        ["icon"] = "mdi:lock",
+                        ["name"] = ComputeEntityName(
+                            name    : "Close Zigbee network",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.ZigbeeNetworkManagement))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ZigbeeNetwork}/set",
+                        ["payload_press"] = "close"
+                    });
+                }
+
+                if (endpoint.HasCapability(OpenNettyCapabilities.ZigbeeSupervision))
+                {
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "f6a3d89f-a3a4-4776-a6b0-a0e3328183ee"u8),
+                        ["icon"] = "mdi:eye-check",
+                        ["name"] = ComputeEntityName(
+                            name    : "Enable supervisor mode",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.ZigbeeSupervision))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ZigbeeSupervision}/set",
+                        ["payload_press"] = "enable"
+                    });
+
+                    components.Add($"entity{components.Count.ToString(CultureInfo.InvariantCulture)}", new JsonObject
+                    {
+                        ["platform"] = "button",
+                        ["unique_id"] = ComputeEntityUniqueId(endpoint, "35f91e70-674d-4977-9475-ba231553051d"u8),
+                        ["icon"] = "mdi:eye-remove",
+                        ["name"] = ComputeEntityName(
+                            name    : "Disable supervisor mode",
+                            endpoint: endpoint,
+                            setting : null,
+                            count   : await _manager.EnumerateEndpointsAsync(cancellationToken)
+                                .Where(endpoint => endpoint.Device == device)
+                                .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.ZigbeeSupervision))
+                                .CountAsync(cancellationToken)),
+                        ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ZigbeeSupervision}/set",
+                        ["payload_press"] = "disable"
                     });
                 }
             }

--- a/src/OpenNetty/IOpenNettyService.cs
+++ b/src/OpenNetty/IOpenNettyService.cs
@@ -37,7 +37,7 @@ public interface IOpenNettyService
         OpenNettyMedium? medium = null,
         OpenNettyMode? mode = null,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -68,7 +68,7 @@ public interface IOpenNettyService
         OpenNettyMode? mode = null,
         Func<OpenNettyCommand, ValueTask<bool>>? filter = null,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -90,7 +90,7 @@ public interface IOpenNettyService
         OpenNettyMedium? medium = null,
         OpenNettyMode? mode = null,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -115,7 +115,7 @@ public interface IOpenNettyService
         OpenNettyMedium? medium = null,
         OpenNettyMode? mode = null,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -146,7 +146,7 @@ public interface IOpenNettyService
         OpenNettyMode? mode = null,
         Func<OpenNettyCommand, ValueTask<bool>>? filter = null,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -164,7 +164,7 @@ public interface IOpenNettyService
     IAsyncObservable<OpenNettyMessage> ObserveMessagesAsync(
         OpenNettyMessage message,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -179,7 +179,7 @@ public interface IOpenNettyService
     ValueTask SendMessageAsync(
         OpenNettyMessage message,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -203,6 +203,6 @@ public interface IOpenNettyService
         OpenNettyMedium? medium = null,
         OpenNettyMode? mode = null,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/OpenNetty/IOpenNettyWorker.cs
+++ b/src/OpenNetty/IOpenNettyWorker.cs
@@ -19,12 +19,14 @@ public interface IOpenNettyWorker
     /// Processes incoming and outgoing notifications for the specified gateway.
     /// </summary>
     /// <param name="gateway">The gateway.</param>
+    /// <param name="options">The worker options.</param>
     /// <param name="reader">The channel reader used to iterate incoming notifications.</param>
     /// <param name="writer">The channel writer used to dispatch outgoing notifications.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>A <see cref="Task"/> that can be used to monitor the asynchronous operation.</returns>
     Task ProcessNotificationsAsync(
         OpenNettyGateway gateway,
+        OpenNettyWorkerOptions options,
         ChannelReader<OpenNettyNotification> reader,
         ChannelWriter<OpenNettyNotification> writer,
         CancellationToken cancellationToken);

--- a/src/OpenNetty/OpenNettyBuilder.cs
+++ b/src/OpenNetty/OpenNettyBuilder.cs
@@ -352,8 +352,10 @@ public sealed class OpenNettyBuilder
                 null => (OpenNettyAddress?) null,
 
                 OpenNettyAddressType.Nitoo => OpenNettyAddress.FromNitooAddress(
-                    identifier: uint.Parse(device?.SerialNumber ?? throw new InvalidOperationException(SR.FormatID0089("SerialNumber")), CultureInfo.InvariantCulture),
-                    unit      : (byte?) (uint?) endpoint.Parent?.Attribute("Id") ?? 0),
+                    identifier: uint.Parse(
+                        (string?) endpoint.Attribute("Id") ?? device?.SerialNumber ??
+                        throw new InvalidOperationException(SR.FormatID0089("SerialNumber")), CultureInfo.InvariantCulture),
+                    unit      : (byte?) (uint?) endpoint.Attribute("Unit") ?? unit?.Definition.Id ?? 0),
 
                 OpenNettyAddressType.ScsLightPoint => OpenNettyAddress.FromScsLightPointAddress(
                     extension: (byte?) (uint?) endpoint.Attribute("Extension") ?? 0,
@@ -363,8 +365,9 @@ public sealed class OpenNettyBuilder
                     point    : (byte?) (uint?) endpoint.Attribute("Point")),
 
                 OpenNettyAddressType.Zigbee => OpenNettyAddress.FromHexadecimalZigbeeAddress(
-                    identifier: device?.SerialNumber ?? throw new InvalidOperationException(SR.FormatID0094("SerialNumber")),
-                    unit      : (byte?) (uint?) endpoint.Parent?.Attribute("Id") ?? 0),
+                    identifier: (string?) endpoint.Attribute("Id") ?? device?.SerialNumber ??
+                        throw new InvalidOperationException(SR.FormatID0094("SerialNumber")),
+                    unit      : (byte?) (uint?) endpoint.Attribute("Unit") ?? unit?.Definition.Id ?? 0),
 
                 _ => throw new InvalidOperationException(SR.FormatID0088(name, "Type"))
             };
@@ -375,7 +378,10 @@ public sealed class OpenNettyBuilder
                 Capabilities = device is null && unit is null ? GetCapabilities(endpoint) : [],
                 Description = (string?) endpoint.Attribute("Description"),
                 Device = device,
-                Gateway = (string?) endpoint.Attribute("Gateway") is string gateway ? FindGatewayByName(gateways, gateway) : null,
+                Gateway = (string?) endpoint.Attribute("Gateway") is string gateway ?
+                    FindGatewayByName(gateways, gateway) :
+                    gateways.FirstOrDefault(gateway => gateway.Protocol == protocol)
+                    ?? throw new InvalidOperationException(SR.FormatID0120(protocol)),
                 Medium = device?.Definition.Medium,
                 Name = name ?? ComputeDefaultEndpointName(protocol, address, device, unit),
                 Protocol = protocol,

--- a/src/OpenNetty/OpenNettyCapabilities.cs
+++ b/src/OpenNetty/OpenNettyCapabilities.cs
@@ -237,6 +237,11 @@ public static class OpenNettyCapabilities
     public static readonly OpenNettyCapability ZigbeeBinding = new("Zigbee binding");
 
     /// <summary>
+    /// Zigbee network management.
+    /// </summary>
+    public static readonly OpenNettyCapability ZigbeeNetworkManagement = new("Zigbee network management");
+
+    /// <summary>
     /// Zigbee supervision.
     /// </summary>
     public static readonly OpenNettyCapability ZigbeeSupervision = new("Zigbee supervision");

--- a/src/OpenNetty/OpenNettyCommands.cs
+++ b/src/OpenNetty/OpenNettyCommands.cs
@@ -141,6 +141,31 @@ public static class OpenNettyCommands
         public static readonly OpenNettyCommand BatteryWeak = new(OpenNettyCategories.Management, "24");
 
         /// <summary>
+        /// Create Zigbee network (WHAT = 30).
+        /// </summary>
+        public static readonly OpenNettyCommand CreateZigbeeNetwork = new(OpenNettyCategories.Management, "30");
+
+        /// <summary>
+        /// Close Zigbee network (WHAT = 31).
+        /// </summary>
+        public static readonly OpenNettyCommand CloseZigbeeNetwork = new(OpenNettyCategories.Management, "31");
+
+        /// <summary>
+        /// Open Zigbee network (WHAT = 32).
+        /// </summary>
+        public static readonly OpenNettyCommand OpenZigbeeNetwork = new(OpenNettyCategories.Management, "32");
+
+        /// <summary>
+        /// Join Zigbee network (WHAT = 33).
+        /// </summary>
+        public static readonly OpenNettyCommand JoinZigbeeNetwork = new(OpenNettyCategories.Management, "33");
+
+        /// <summary>
+        /// Leave Zigbee network (WHAT = 34).
+        /// </summary>
+        public static readonly OpenNettyCommand LeaveZigbeeNetwork = new(OpenNettyCategories.Management, "34");
+
+        /// <summary>
         /// Supervisor (WHAT = 66).
         /// </summary>
         public static readonly OpenNettyCommand Supervisor = new(OpenNettyCategories.Management, "66");

--- a/src/OpenNetty/OpenNettyConfiguration.cs
+++ b/src/OpenNetty/OpenNettyConfiguration.cs
@@ -49,7 +49,7 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
                     },
                     Capabilities = [],
                     Device = device,
-                    Gateway = null,
+                    Gateway = options.Gateways.First(gateway => gateway.Protocol == device.Definition.Protocol),
                     Medium = device.Definition.Medium,
                     Name = ComputeDefaultEndpointName(device),
                     Protocol = device.Definition.Protocol,
@@ -91,7 +91,8 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
                         },
                         Capabilities = [],
                         Device = device,
-                        Gateway = null,
+                        Gateway = options.Gateways.FirstOrDefault(gateway => gateway.Protocol == device.Definition.Protocol)
+                            ?? throw new InvalidOperationException(SR.FormatID0120(device.Definition.Protocol)),
                         Medium = device.Definition.Medium,
                         Name = ComputeDefaultEndpointName(device, definition),
                         Protocol = device.Definition.Protocol,
@@ -139,6 +140,23 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
                  endpoint.Name.Contains('*', StringComparison.OrdinalIgnoreCase)))
             {
                 return ValidateOptionsResult.Fail(SR.FormatID2000(endpoint.Name));
+            }
+
+            switch (endpoint.GetBooleanSetting(OpenNettySettings.ActionValidation))
+            {
+                case null: break;
+
+                case not null:
+                    if (endpoint.Protocol is not OpenNettyProtocol.Nitoo)
+                    {
+                        return ValidateOptionsResult.Fail(SR.GetResourceString(SR.ID2010));
+                    }
+
+                    if (endpoint.Address is null)
+                    {
+                        return ValidateOptionsResult.Fail(SR.GetResourceString(SR.ID2011));
+                    }
+                    break;
             }
 
             switch (endpoint.GetStringSetting(OpenNettySettings.ActuatorType))

--- a/src/OpenNetty/OpenNettyController.cs
+++ b/src/OpenNetty/OpenNettyController.cs
@@ -70,11 +70,9 @@ public class OpenNettyController
             ],
             address          : endpoint.Address,
             medium           : endpoint.Medium,
-            mode             : OpenNettyMode.Unicast,
+            mode             : null,
             gateway          : endpoint.Gateway,
-            options          : endpoint.GetBooleanSetting(OpenNettySettings.ActionValidation) is not false ?
-                OpenNettyTransmissionOptions.RequireActionValidation :
-                OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -102,7 +100,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -130,7 +128,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -158,7 +156,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -186,7 +184,77 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Multicast,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
+            cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Asks the specified endpoint to close a Zigbee network.
+    /// </summary>
+    /// <param name="endpoint">The endpoint.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
+    public virtual ValueTask CloseNetworkAsync(
+        OpenNettyEndpoint endpoint,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (!endpoint.HasCapability(OpenNettyCapabilities.ZigbeeNetworkManagement))
+        {
+            throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
+        }
+
+        return _service.ExecuteCommandAsync(
+            protocol         : endpoint.Protocol,
+            command          : OpenNettyCommands.Management.CloseZigbeeNetwork,
+            address          : endpoint.Address,
+            medium           : endpoint.Medium,
+            mode             : null,
+            gateway          : endpoint.Gateway,
+            options          : GetTransmissionOptions(endpoint),
+            cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Asks the specified endpoint to create a Zigbee network.
+    /// </summary>
+    /// <param name="endpoint">The endpoint.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
+    public virtual ValueTask CreateNetworkAsync(
+        OpenNettyEndpoint endpoint,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (!endpoint.HasCapability(OpenNettyCapabilities.ZigbeeNetworkManagement))
+        {
+            throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
+        }
+
+        // Note: creating a Zigbee network can take a while and the gateway only returns an
+        // acknowledgment frame after the operation is complete. To ensure the gateway is
+        // given enough time to create the network, the timeouts are increased if necessary.
+        var options = GetTransmissionOptions(endpoint);
+        if (options.FrameAcknowledgementTimeout < TimeSpan.FromSeconds(20))
+        {
+            options = options with { FrameAcknowledgementTimeout = TimeSpan.FromSeconds(20) };
+        }
+
+        if (options.OutgoingMessageProcessingTimeout < TimeSpan.FromSeconds(30))
+        {
+            options = options with { OutgoingMessageProcessingTimeout = TimeSpan.FromSeconds(30) };
+        }
+
+        return _service.ExecuteCommandAsync(
+            protocol         : endpoint.Protocol,
+            command          : OpenNettyCommands.Management.CreateZigbeeNetwork,
+            address          : endpoint.Address,
+            medium           : endpoint.Medium,
+            mode             : null,
+            gateway          : endpoint.Gateway,
+            options          : options,
             cancellationToken: cancellationToken);
     }
 
@@ -214,7 +282,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Broadcast,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -242,7 +310,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Broadcast,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -270,7 +338,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Broadcast,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -301,7 +369,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Broadcast,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -329,7 +397,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Broadcast,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -357,7 +425,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Broadcast,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -385,7 +453,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Broadcast,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -413,7 +481,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Broadcast,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -444,7 +512,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Broadcast,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -515,7 +583,7 @@ public class OpenNettyController
                         medium   : endpoint.Medium,
                         mode     : null),
                     gateway          : endpoint.Gateway,
-                    options          : OpenNettyTransmissionOptions.None,
+                    options          : GetTransmissionOptions(endpoint),
                     cancellationToken: cancellationToken);
 
                 await foreach (var result in messages
@@ -560,7 +628,7 @@ public class OpenNettyController
                         command == OpenNettyCommands.Lighting.On90 ||
                         command == OpenNettyCommands.Lighting.On100),
                     gateway          : endpoint.Gateway,
-                    options          : OpenNettyTransmissionOptions.None,
+                    options          : GetTransmissionOptions(endpoint),
                     cancellationToken: cancellationToken);
 
                 await foreach (var result in results
@@ -631,7 +699,7 @@ public class OpenNettyController
                     protocol         : endpoint.Protocol,
                     dimension        : OpenNettyDimensions.Automation.ShutterStatus,
                     gateway          : endpoint.Gateway,
-                    options          : OpenNettyTransmissionOptions.None,
+                    options          : GetTransmissionOptions(endpoint),
                     cancellationToken: cancellationToken);
 
                 return dimensions
@@ -710,7 +778,7 @@ public class OpenNettyController
                     protocol         : endpoint.Protocol,
                     dimension        : OpenNettyDimensions.Automation.ShutterStatus,
                     gateway          : endpoint.Gateway,
-                    options          : OpenNettyTransmissionOptions.None,
+                    options          : GetTransmissionOptions(endpoint),
                     cancellationToken: cancellationToken);
 
                 await foreach (var result in dimensions
@@ -754,7 +822,7 @@ public class OpenNettyController
                         command == OpenNettyCommands.Automation.Up   ||
                         command == OpenNettyCommands.Automation.Down),
                     gateway          : endpoint.Gateway,
-                    options          : OpenNettyTransmissionOptions.None,
+                    options          : GetTransmissionOptions(endpoint),
                     cancellationToken: cancellationToken);
 
                 await foreach (var result in results
@@ -834,7 +902,7 @@ public class OpenNettyController
                         command == OpenNettyCommands.Lighting.On90 ||
                         command == OpenNettyCommands.Lighting.On100),
                     gateway          : endpoint.Gateway,
-                    options          : OpenNettyTransmissionOptions.None,
+                    options          : GetTransmissionOptions(endpoint),
                     cancellationToken: cancellationToken);
 
                 return results
@@ -873,7 +941,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Broadcast,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -928,12 +996,12 @@ public class OpenNettyController
                     medium   : endpoint.Medium,
                     mode     : null),
                 gateway          : endpoint.Gateway,
-                options          : OpenNettyTransmissionOptions.None,
+                options          : GetTransmissionOptions(endpoint),
                 cancellationToken: cancellationToken);
 
             return await messages
                 .Where(static message => message.Dimension == OpenNettyDimensions.Lighting.DimmerLevelSpeed ||
-                                            message.Dimension == OpenNettyDimensions.Lighting.DimmerStatus)
+                                         message.Dimension == OpenNettyDimensions.Lighting.DimmerStatus)
                 .Where(message => message.Address == endpoint.Address)
                 .Select(static arguments => (byte) (byte.Parse(arguments.Values[0], CultureInfo.InvariantCulture) - 100))
                 .FirstOrDefault()
@@ -962,7 +1030,7 @@ public class OpenNettyController
                     command == OpenNettyCommands.Lighting.On90 ||
                     command == OpenNettyCommands.Lighting.On100),
                 gateway          : endpoint.Gateway,
-                options          : OpenNettyTransmissionOptions.None,
+                options          : GetTransmissionOptions(endpoint),
                 cancellationToken: cancellationToken) switch
                 {
                     var command when command == OpenNettyCommands.Lighting.Off   => 0,
@@ -1009,7 +1077,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
 
         return new DateTimeOffset(
@@ -1053,9 +1121,9 @@ public class OpenNettyController
             dimension        : OpenNettyDimensions.Diagnostics.DeviceDescription,
             address          : endpoint.Address,
             medium           : endpoint.Medium,
-            mode             : OpenNettyMode.Unicast,
+            mode             : null,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
 
         return OpenNettyModels.Diagnostics.DeviceDescription.CreateFromDeviceDescription(values);
@@ -1085,7 +1153,7 @@ public class OpenNettyController
                 medium           : endpoint.Medium,
                 mode             : null,
                 gateway          : endpoint.Gateway,
-                options          : OpenNettyTransmissionOptions.None,
+                options          : GetTransmissionOptions(endpoint),
                 cancellationToken: cancellationToken);
 
             return new Version(
@@ -1130,7 +1198,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
 
         return new Version(
@@ -1165,9 +1233,9 @@ public class OpenNettyController
                 command : OpenNettyCommands.Diagnostics.MemoryRead,
                 address : endpoint.Address,
                 medium  : endpoint.Medium,
-                mode    : OpenNettyMode.Unicast),
+                mode    : null),
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken).Replay();
 
         await using var connection = await messages.ConnectAsync();
@@ -1230,9 +1298,9 @@ public class OpenNettyController
                 command : OpenNettyCommands.Diagnostics.MemoryRead,
                 address : endpoint.Address,
                 medium  : endpoint.Medium,
-                mode    : OpenNettyMode.Unicast),
+                mode    : null),
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
 
         return await messages
@@ -1306,7 +1374,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken) switch
             {
                 [_, { Length: > 0 } value, ..] => byte.Parse(value, CultureInfo.InvariantCulture) switch
@@ -1372,7 +1440,7 @@ public class OpenNettyController
                 medium           : endpoint.Medium,
                 mode             : null,
                 gateway          : endpoint.Gateway,
-                options          : OpenNettyTransmissionOptions.None,
+                options          : GetTransmissionOptions(endpoint),
                 cancellationToken: cancellationToken) switch
             {
                 ["10", string position, ..] => byte.Parse(position, CultureInfo.InvariantCulture) switch
@@ -1404,7 +1472,7 @@ public class OpenNettyController
                     command == OpenNettyCommands.Automation.Up   ||
                     command == OpenNettyCommands.Automation.Down),
                 gateway          : endpoint.Gateway,
-                options          : OpenNettyTransmissionOptions.None,
+                options          : GetTransmissionOptions(endpoint),
                 cancellationToken: cancellationToken) switch
             {
                 OpenNettyCommand command when command == OpenNettyCommands.Automation.Stop
@@ -1446,9 +1514,9 @@ public class OpenNettyController
             dimension        : OpenNettyDimensions.TemperatureControl.SmartMeterIndexes,
             address          : endpoint.Address,
             medium           : endpoint.Medium,
-            mode             : OpenNettyMode.Unicast,
+            mode             : null,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
 
         return OpenNettyModels.TemperatureControl.SmartMeterIndexes.CreateFromDimensionValues(values);
@@ -1543,7 +1611,7 @@ public class OpenNettyController
                     command == OpenNettyCommands.Lighting.On90 ||
                     command == OpenNettyCommands.Lighting.On100),
                 gateway          : endpoint.Gateway,
-                options          : OpenNettyTransmissionOptions.None,
+                options          : GetTransmissionOptions(endpoint),
                 cancellationToken: cancellationToken) != OpenNettyCommands.Lighting.Off ?
                     OpenNettyModels.Lighting.SwitchState.On :
                     OpenNettyModels.Lighting.SwitchState.Off
@@ -1575,9 +1643,9 @@ public class OpenNettyController
             dimension        : OpenNettyDimensions.Diagnostics.UnitDescription,
             address          : endpoint.Address,
             medium           : endpoint.Medium,
-            mode             : OpenNettyMode.Unicast,
+            mode             : null,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
 
         return OpenNettyModels.Diagnostics.UnitDescription.CreateFromUnitDescription(values);
@@ -1610,7 +1678,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
 
         return new TimeSpan(
@@ -1656,6 +1724,90 @@ public class OpenNettyController
     }
 
     /// <summary>
+    /// Asks the specified endpoint to join a Zigbee network.
+    /// </summary>
+    /// <param name="endpoint">The endpoint.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
+    public virtual ValueTask JoinNetworkAsync(
+        OpenNettyEndpoint endpoint,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (!endpoint.HasCapability(OpenNettyCapabilities.ZigbeeNetworkManagement))
+        {
+            throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
+        }
+
+        // Note: joining a Zigbee network can take a while and the gateway only returns an
+        // acknowledgment frame after the operation is complete. To ensure the gateway is
+        // given enough time to join the network, the timeouts are increased if necessary.
+        var options = GetTransmissionOptions(endpoint);
+        if (options.FrameAcknowledgementTimeout < TimeSpan.FromSeconds(20))
+        {
+            options = options with { FrameAcknowledgementTimeout = TimeSpan.FromSeconds(20) };
+        }
+
+        if (options.OutgoingMessageProcessingTimeout < TimeSpan.FromSeconds(30))
+        {
+            options = options with { OutgoingMessageProcessingTimeout = TimeSpan.FromSeconds(30) };
+        }
+
+        return _service.ExecuteCommandAsync(
+            protocol         : endpoint.Protocol,
+            command          : OpenNettyCommands.Management.JoinZigbeeNetwork,
+            address          : endpoint.Address,
+            medium           : endpoint.Medium,
+            mode             : null,
+            gateway          : endpoint.Gateway,
+            options          : options,
+            cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Asks the specified endpoint to leave a Zigbee network.
+    /// </summary>
+    /// <param name="endpoint">The endpoint.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
+    public virtual ValueTask LeaveNetworkAsync(
+        OpenNettyEndpoint endpoint,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (!endpoint.HasCapability(OpenNettyCapabilities.ZigbeeNetworkManagement))
+        {
+            throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
+        }
+
+        // Note: leaving a Zigbee network can take a while and the gateway only returns an
+        // acknowledgment frame after the operation is complete. To ensure the gateway is
+        // given enough time to leave the network, the timeouts are increased if necessary.
+        var options = GetTransmissionOptions(endpoint);
+        if (options.FrameAcknowledgementTimeout < TimeSpan.FromSeconds(20))
+        {
+            options = options with { FrameAcknowledgementTimeout = TimeSpan.FromSeconds(20) };
+        }
+
+        if (options.OutgoingMessageProcessingTimeout < TimeSpan.FromSeconds(30))
+        {
+            options = options with { OutgoingMessageProcessingTimeout = TimeSpan.FromSeconds(30) };
+        }
+
+        return _service.ExecuteCommandAsync(
+            protocol         : endpoint.Protocol,
+            command          : OpenNettyCommands.Management.LeaveZigbeeNetwork,
+            address          : endpoint.Address,
+            medium           : endpoint.Medium,
+            mode             : null,
+            gateway          : endpoint.Gateway,
+            options          : options,
+            cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
     /// Moves the specified shutter endpoint down.
     /// </summary>
     /// <param name="endpoint">The endpoint.</param>
@@ -1685,10 +1837,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : endpoint.Protocol is OpenNettyProtocol.Nitoo &&
-                endpoint.GetBooleanSetting(OpenNettySettings.ActionValidation) is not false ?
-                OpenNettyTransmissionOptions.RequireActionValidation :
-                OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -1722,10 +1871,35 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : endpoint.Protocol is OpenNettyProtocol.Nitoo &&
-                endpoint.GetBooleanSetting(OpenNettySettings.ActionValidation) is not false ?
-                OpenNettyTransmissionOptions.RequireActionValidation :
-                OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
+            cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Asks the specified endpoint to open a Zigbee network.
+    /// </summary>
+    /// <param name="endpoint">The endpoint.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
+    public virtual ValueTask OpenNetworkAsync(
+        OpenNettyEndpoint endpoint,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (!endpoint.HasCapability(OpenNettyCapabilities.ZigbeeNetworkManagement))
+        {
+            throw new InvalidOperationException(SR.GetResourceString(SR.ID0076));
+        }
+
+        return _service.ExecuteCommandAsync(
+            protocol         : endpoint.Protocol,
+            command          : OpenNettyCommands.Management.OpenZigbeeNetwork,
+            address          : endpoint.Address,
+            medium           : endpoint.Medium,
+            mode             : null,
+            gateway          : endpoint.Gateway,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -1751,11 +1925,9 @@ public class OpenNettyController
             command          : OpenNettyCommands.Diagnostics.MemoryReset,
             address          : endpoint.Address,
             medium           : endpoint.Medium,
-            mode             : OpenNettyMode.Unicast,
+            mode             : null,
             gateway          : endpoint.Gateway,
-            options          : endpoint.GetBooleanSetting(OpenNettySettings.ActionValidation) is not false ?
-                OpenNettyTransmissionOptions.RequireActionValidation :
-                OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -1781,7 +1953,7 @@ public class OpenNettyController
         }
 
         // Note: for unknown reasons, specifying a SPEED parameter that is less than 10 (2 seconds * 5)
-        // results in an immediumte - rather than progressive - brightness change on Nitoo devices when
+        // results in an immediate - rather than progressive - brightness change on Nitoo devices when
         // the requested level is higher than 50%. To discourage users of this API to set values that
         // may exhibit this issue, a sanity check is performed here to require an adequate duration.
         if (endpoint.Protocol is OpenNettyProtocol.Nitoo && level is > 50 &&
@@ -1818,7 +1990,7 @@ public class OpenNettyController
                     medium           : endpoint.Medium,
                     mode             : null,
                     gateway          : endpoint.Gateway,
-                    options          : OpenNettyTransmissionOptions.None,
+                    options          : GetTransmissionOptions(endpoint),
                     cancellationToken: cancellationToken);
             }
 
@@ -1836,11 +2008,9 @@ public class OpenNettyController
                     ],
                     address          : endpoint.Address,
                     medium           : endpoint.Medium,
-                    mode             : OpenNettyMode.Unicast,
+                    mode             : null,
                     gateway          : endpoint.Gateway,
-                    options          : endpoint.GetBooleanSetting(OpenNettySettings.ActionValidation) is not false ?
-                        OpenNettyTransmissionOptions.RequireActionValidation :
-                        OpenNettyTransmissionOptions.None,
+                    options          : GetTransmissionOptions(endpoint),
                     cancellationToken: cancellationToken);
             }
 
@@ -1857,7 +2027,7 @@ public class OpenNettyController
                 medium           : endpoint.Medium,
                 mode             : null,
                 gateway          : endpoint.Gateway,
-                options          : OpenNettyTransmissionOptions.None,
+                options          : GetTransmissionOptions(endpoint),
                 cancellationToken: cancellationToken);
         }
 
@@ -1880,12 +2050,9 @@ public class OpenNettyController
                 },
                 address          : endpoint.Address,
                 medium           : endpoint.Medium,
-                mode             : endpoint.Protocol is OpenNettyProtocol.Nitoo ? OpenNettyMode.Unicast : null,
+                mode             : null,
                 gateway          : endpoint.Gateway,
-                options          : endpoint.Protocol is OpenNettyProtocol.Nitoo &&
-                    endpoint.GetBooleanSetting(OpenNettySettings.ActionValidation) is not false ?
-                    OpenNettyTransmissionOptions.RequireActionValidation :
-                    OpenNettyTransmissionOptions.None,
+                options          : GetTransmissionOptions(endpoint),
                 cancellationToken: cancellationToken);
         }
 
@@ -1936,7 +2103,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -2000,7 +2167,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Multicast,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -2047,7 +2214,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : OpenNettyMode.Multicast,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -2087,7 +2254,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -2128,11 +2295,9 @@ public class OpenNettyController
             }],
             address          : endpoint.Address,
             medium           : endpoint.Medium,
-            mode             : OpenNettyMode.Unicast,
+            mode             : null,
             gateway          : endpoint.Gateway,
-            options          : endpoint.GetBooleanSetting(OpenNettySettings.ActionValidation) is not false ?
-                OpenNettyTransmissionOptions.RequireActionValidation :
-                OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -2166,10 +2331,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : endpoint.Protocol is OpenNettyProtocol.Nitoo &&
-                endpoint.GetBooleanSetting(OpenNettySettings.ActionValidation) is not false ?
-                OpenNettyTransmissionOptions.RequireActionValidation :
-                OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -2209,10 +2371,7 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : endpoint.Protocol is OpenNettyProtocol.Nitoo &&
-                endpoint.GetBooleanSetting(OpenNettySettings.ActionValidation) is not false ?
-                OpenNettyTransmissionOptions.RequireActionValidation :
-                OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
 
@@ -2239,21 +2398,6 @@ public class OpenNettyController
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0112));
         }
 
-        var options = OpenNettyTransmissionOptions.None;
-
-        if (endpoint.Protocol is OpenNettyProtocol.Nitoo &&
-            endpoint.GetBooleanSetting(OpenNettySettings.ActionValidation) is not false)
-        {
-            options |= OpenNettyTransmissionOptions.RequireActionValidation;
-        }
-
-        // If the endpoint was configured to use the push-button mode, always disable retransmissions
-        // as ON commands are not idempotent when using this mode, which may result in unwanted results.
-        if (endpoint.GetStringSetting(OpenNettySettings.SwitchMode) is OpenNettySettings.SwitchModes.PushButton)
-        {
-            options |= OpenNettyTransmissionOptions.DisallowRetransmissions;
-        }
-
         return _service.ExecuteCommandAsync(
             protocol         : endpoint.Protocol,
             command          : OpenNettyCommands.Lighting.On,
@@ -2261,7 +2405,13 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : options,
+            options          : GetTransmissionOptions(endpoint) with
+            {
+                // If the endpoint was configured to use the push-button mode, always disable retransmissions
+                // as ON commands are not idempotent when using this mode, which may result in unwanted results.
+                DisallowRetransmissions = endpoint.GetStringSetting(OpenNettySettings.SwitchMode)
+                    is OpenNettySettings.SwitchModes.PushButton
+            },
             cancellationToken: cancellationToken);
     }
 
@@ -2312,12 +2462,9 @@ public class OpenNettyController
                     OpenNettyCommands.Lighting.On,
                 address          : endpoint.Address,
                 medium           : endpoint.Medium,
-                mode             : endpoint.Protocol is OpenNettyProtocol.Nitoo ? OpenNettyMode.Unicast : null,
+                mode             : null,
                 gateway          : endpoint.Gateway,
-                options          : endpoint.Protocol is OpenNettyProtocol.Nitoo &&
-                    endpoint.GetBooleanSetting(OpenNettySettings.ActionValidation) is not false ?
-                    OpenNettyTransmissionOptions.RequireActionValidation :
-                    OpenNettyTransmissionOptions.None,
+                options          : GetTransmissionOptions(endpoint),
                 cancellationToken: cancellationToken);
         }
 
@@ -2330,7 +2477,7 @@ public class OpenNettyController
                 medium           : endpoint.Medium,
                 mode             : null,
                 gateway          : endpoint.Gateway,
-                options          : OpenNettyTransmissionOptions.None,
+                options          : GetTransmissionOptions(endpoint),
                 cancellationToken: cancellationToken);
         }
     }
@@ -2359,7 +2506,26 @@ public class OpenNettyController
             medium           : endpoint.Medium,
             mode             : null,
             gateway          : endpoint.Gateway,
-            options          : OpenNettyTransmissionOptions.None,
+            options          : GetTransmissionOptions(endpoint),
             cancellationToken: cancellationToken);
     }
+
+    /// <summary>
+    /// Gets the transmission options that will be used to communicate with the specified endpoint.
+    /// </summary>
+    /// <param name="endpoint">The endpoint.</param>
+    /// <returns>The transmission options that will be used to communicate with the specified endpoint.</returns>
+    protected virtual OpenNettyTransmissionOptions GetTransmissionOptions(OpenNettyEndpoint endpoint)
+        => endpoint.GetBooleanSetting(OpenNettySettings.ActionValidation) switch
+        {
+            null => endpoint.Gateway.Options.DefaultTransmissionOptions,
+            true => endpoint.Gateway.Options.DefaultTransmissionOptions with
+            {
+                IgnoreActionValidation = true
+            },
+            false => endpoint.Gateway.Options.DefaultTransmissionOptions with
+            {
+                IgnoreActionValidation = false
+            }
+        };
 }

--- a/src/OpenNetty/OpenNettyCoordinator.cs
+++ b/src/OpenNetty/OpenNettyCoordinator.cs
@@ -93,106 +93,142 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     Type    : OpenNettyMessageType.BusCommand or OpenNettyMessageType.DimensionSet } message }
                 => AsyncObservable.Return<(OpenNettyNotification Notification, OpenNettyMessage Message)>((notification, message)),
 
+            // Note: while Zigbee devices report back state changes to the gateway when the supervisor mode
+            // is enabled, this mode suffers from two major limitations: it is not recommended to use it on
+            // more than one Zigbee gateway at a time and state changes are always throttled so that they are
+            // only reported 3 seconds after the last change (intermediate changes are also not reported).
+            // To mitigate these limitations, the outgoing Zigbee BUS COMMAND and DIMENSION SET messages that
+            // have been acknowledged by the gateway are monitored so that changes can be reported immediately.
+            OpenNettyNotifications.MessageSent {
+                Session.Type: OpenNettySessionType.Generic,
+                Message: {
+                    Protocol: OpenNettyProtocol.Zigbee,
+                    Type    : OpenNettyMessageType.BusCommand or OpenNettyMessageType.DimensionSet } message }
+                => AsyncObservable.Return<(OpenNettyNotification Notification, OpenNettyMessage Message)>((notification, message)),
+
             _ => AsyncObservable.Empty<(OpenNettyNotification Notification, OpenNettyMessage Message)>()
         })
         .Do(async arguments =>
         {
+            var (notification, message) = arguments;
+
             // Important: to ensure the order of events is preserved, this RX event handler processes incoming and outgoing
             // messages sequentially. As such, it is critical that this asynchronous method completes as quickly as possible.
 
-            switch (arguments)
+            switch ((notification, message))
             {
                 // The switch state and the brightness level of an endpoint can be inferred from 6 types of messages:
                 //
-                //   - For Nitoo devices, from an incoming or outgoing "OFF" or "ON" BUS COMMAND message.
-                //   - For SCS/Zigbee devices, from an incoming "OFF" or "ON" - parameterized or not - BUS COMMAND message.
-                //   - For SCS/Zigbee devices, from an incoming "ON%" BUS COMMAND message.
-                //   - For SCS/Zigbee devices, from an incoming "DIMMER SPEED LEVEL" or "DIMMER STATUS" DIMENSION READ message.
-                //   - For Nitoo devices, from an incoming "UNIT DESCRIPTION" DIMENSION READ message.
-                //   - For Nitoo devices, from an outgoing "DIMMER SPEED LEVEL" DIMENSION SET message.
+                //   - From an "OFF" or "ON" BUS COMMAND message:
+                //     * For Nitoo and Zigbee devices, the message MAY be incoming or outgoing.
+                //     * For SCS devices, the message MUST be incoming.
+                //
+                //   - From an incoming or outgoing "ON%" BUS COMMAND message:
+                //     * For SCS devices, the message MUST be incoming.
+                //     * For Zigbee devices, the message MAY be incoming or outgoing.
+                //
+                //   - For SCS and Zigbee devices, from an incoming "DIMMER SPEED LEVEL" or "DIMMER STATUS" DIMENSION READ message.
+                //   - For Nitoo and Zigbee devices, from an outgoing "DIMMER SPEED LEVEL" DIMENSION SET message.
+                //   - For Nitoo devices, from an incoming "UNIT DESCRIPTION=129" DIMENSION READ message (non-dimmable devices).
+                //   - For Nitoo devices, from an incoming "UNIT DESCRIPTION=143" DIMENSION READ message (dimmable devices).
 
-                case (OpenNettyNotification notification,
-                      OpenNettyMessage { Protocol: OpenNettyProtocol.Nitoo,
+                case (OpenNettyNotifications.MessageReceived or OpenNettyNotifications.MessageSent,
+                      OpenNettyMessage { Protocol: OpenNettyProtocol.Nitoo or OpenNettyProtocol.Zigbee,
                                          Type    : OpenNettyMessageType.BusCommand,
-                                         Command : OpenNettyCommand command,
-                                         Address : OpenNettyAddress address,
-                                         Mode    : OpenNettyMode mode })
-                    when command == OpenNettyCommands.Lighting.Off || command == OpenNettyCommands.Lighting.On:
+                                         Command : OpenNettyCommand,
+                                         Address : not null }) or
+                     (OpenNettyNotifications.MessageReceived,
+                      OpenNettyMessage { Protocol: OpenNettyProtocol.Scs,
+                                         Type    : OpenNettyMessageType.BusCommand,
+                                         Command : OpenNettyCommand,
+                                         Address : not null })
+                    // Note: ON/OFF BUS COMMAND frames can be parameterized.
+                    when message.Command?.WithParameters([]) == OpenNettyCommands.Lighting.On ||
+                         message.Command?.WithParameters([]) == OpenNettyCommands.Lighting.Off:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
-
-                    // If the message was received and was emitted by the source using
-                    // a broadcast transmission, it is considered as an ON/OFF scenario.
-                    if (notification is OpenNettyNotifications.MessageReceived && mode is OpenNettyMode.Broadcast &&
-                        endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioState))
-                    {
-                        if (command == OpenNettyCommands.Lighting.On)
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
                         {
-                            await _events.PublishAsync(new OnScenarioReportedEventArgs(endpoint));
+                            return;
                         }
 
-                        else
-                        {
-                            await _events.PublishAsync(new OffScenarioReportedEventArgs(endpoint));
-                        }
-                    }
+                        List<Task> tasks = [];
 
-                    List<Task> tasks = [];
-
-                    // Note: outgoing ON/OFF commands sent using broadcast or multicast transmission
-                    // generally don't affect the local output of a Nitoo lighting device. As such,
-                    // the switch state/brightness of the endpoint is only reported if the message was
-                    // received (e.g by a different unit on the same device) or was sent in unicast.
-                    if (mode is OpenNettyMode.Unicast || notification is OpenNettyNotifications.MessageReceived)
-                    {
-                        if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState) &&
-                            endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is null or OpenNettySettings.ActuatorTypes.Lighting)
+                        switch (endpoint.Protocol)
                         {
-                            tasks.Add(ReportStateAsync(endpoint, CancellationToken.None).AsTask());
+                            // Note: outgoing ON/OFF commands sent using broadcast or multicast transmission
+                            // generally don't affect the local output of a Nitoo lighting device. As such,
+                            // the switch state/brightness of the endpoint is only reported if the message was
+                            // received (e.g by a different unit on the same device) or was sent in unicast.
+                            case OpenNettyProtocol.Nitoo when notification is OpenNettyNotifications.MessageReceived:
+                            case OpenNettyProtocol.Nitoo when notification is OpenNettyNotifications.MessageSent && message.Mode is OpenNettyMode.Unicast:
+                            case OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee:
+                                if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
+                                {
+                                    tasks.Add(ReportStateAsync(endpoint, cancellationToken).AsTask());
+                                }
+                                break;
                         }
 
-                        if (endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit.Definition.AssociatedUnitId: byte unit })
+                        // For Nitoo devices, if the ON/OFF command was emitted by a different unit
+                        // on the same device, reflect the state change on the linked endpoint.
+                        if (notification is OpenNettyNotifications.MessageReceived &&
+                            endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit.Definition.AssociatedUnitId: byte unit })
                         {
                             tasks.Add(Task.Run(async () =>
                             {
                                 var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
-                                    OpenNettyAddress.ToNitooAddress(address).Identifier, unit));
+                                    OpenNettyAddress.ToNitooAddress(message.Address.Value).Identifier, unit));
 
-                                if (endpoint is not null &&
-                                    endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState) &&
-                                    endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is null or OpenNettySettings.ActuatorTypes.Lighting)
+                                if (endpoint is not null && endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
                                 {
-                                    await ReportStateAsync(endpoint, CancellationToken.None);
+                                    await ReportStateAsync(endpoint, cancellationToken);
                                 }
-                            }));
+                            }, cancellationToken));
                         }
-                    }
 
-                    if (mode is OpenNettyMode.Broadcast or OpenNettyMode.Multicast && endpoint is { Unit.Scenarios: [_, ..] scenarios })
-                    {
-                        var endpoints = scenarios.ToAsyncEnumerable()
-                            .Where(static scenario => scenario.FunctionCode is < 105)
-                            .SelectAwait(scenario => _manager.FindEndpointByNameAsync(scenario.EndpointName))
-                            .Where(static endpoint => endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit: OpenNettyUnit })
-                            .OfType<OpenNettyEndpoint>()
-                            .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
-                            .Where(static endpoint => endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is
-                                null or OpenNettySettings.ActuatorTypes.Lighting);
+                        // For Nitoo devices, if the message was sent using a broadcast or multicast transmission,
+                        // reflect the state change on all the other endpoints that are part of the same scenario.
+                        if (notification is OpenNettyNotifications.MessageReceived &&
+                            message.Mode is OpenNettyMode.Broadcast or OpenNettyMode.Multicast &&
+                            endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit.Scenarios: [_, ..] scenarios })
+                        {
+                            var endpoints = scenarios.ToAsyncEnumerable()
+                                .Where(static scenario => scenario.FunctionCode is < 105)
+                                .SelectAwait(scenario => _manager.FindEndpointByNameAsync(scenario.EndpointName))
+                                .Where(static endpoint => endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit: OpenNettyUnit })
+                                .OfType<OpenNettyEndpoint>()
+                                .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState));
 
-                        tasks.Add(Parallel.ForEachAsync(endpoints, ReportStateAsync));
-                    }
+                            tasks.Add(Parallel.ForEachAsync(endpoints, ReportStateAsync));
+                        }
 
-                    await Task.WhenAll(tasks);
+                        // If the message was emitted by a Nitoo device using a broadcast
+                        // transmission, it is also considered an ON/OFF scenario.
+                        if (notification is OpenNettyNotifications.MessageReceived &&
+                            message.Mode is OpenNettyMode.Broadcast &&
+                            endpoint.Protocol is OpenNettyProtocol.Nitoo &&
+                            endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioState))
+                        {
+                            if (message.Command == OpenNettyCommands.Lighting.On)
+                            {
+                                tasks.Add(_events.PublishAsync(new OnScenarioReportedEventArgs(endpoint), cancellationToken).AsTask());
+                            }
+
+                            else
+                            {
+                                tasks.Add(_events.PublishAsync(new OffScenarioReportedEventArgs(endpoint), cancellationToken).AsTask());
+                            }
+                        }
+
+                        await Task.WhenAll(tasks);
+                    });
 
                     async ValueTask ReportStateAsync(OpenNettyEndpoint endpoint, CancellationToken cancellationToken)
                     {
-                        if (command == OpenNettyCommands.Lighting.On)
+                        if (message.Command == OpenNettyCommands.Lighting.On)
                         {
                             await _events.PublishAsync(new SwitchStateReportedEventArgs(endpoint,
                                 OpenNettyModels.Lighting.SwitchState.On), cancellationToken);
@@ -214,8 +250,9 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                         }
                         
                         // Note: for Nitoo devices supporting dimming, an ON command always changes the brightness to 100%.
-                        if (command == OpenNettyCommands.Lighting.On && (endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) ||
-                                                                         endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState)))
+                        if (message.Command == OpenNettyCommands.Lighting.On && endpoint.Protocol is OpenNettyProtocol.Nitoo &&
+                           (endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) ||
+                            endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState)))
                         {
                             await _events.PublishAsync(new BrightnessReportedEventArgs(endpoint, 100), cancellationToken);
                         }
@@ -224,77 +261,38 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                 }
 
                 case (OpenNettyNotifications.MessageReceived,
-                      OpenNettyMessage { Protocol: OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee,
+                      OpenNettyMessage { Protocol: OpenNettyProtocol.Scs,
                                          Type    : OpenNettyMessageType.BusCommand,
-                                         Command : OpenNettyCommand command,
-                                         Address : OpenNettyAddress address })
-                    // Note: ON/OFF BUS COMMAND frames can be parameterized.
-                    when command.Category == OpenNettyCategories.Lighting &&
-                        (command.Value    == OpenNettyCommands.Lighting.On.Value ||
-                         command.Value    == OpenNettyCommands.Lighting.Off.Value):
+                                         Command : OpenNettyCommand,
+                                         Address : not null }) or
+                     (OpenNettyNotifications.MessageReceived or OpenNettyNotifications.MessageSent,
+                      OpenNettyMessage { Protocol: OpenNettyProtocol.Zigbee,
+                                         Type    : OpenNettyMessageType.BusCommand,
+                                         Command : OpenNettyCommand,
+                                         Address : not null })
+                    when message.Command == OpenNettyCommands.Lighting.On20 ||
+                         message.Command == OpenNettyCommands.Lighting.On30 ||
+                         message.Command == OpenNettyCommands.Lighting.On40 ||
+                         message.Command == OpenNettyCommands.Lighting.On50 ||
+                         message.Command == OpenNettyCommands.Lighting.On60 ||
+                         message.Command == OpenNettyCommands.Lighting.On70 ||
+                         message.Command == OpenNettyCommands.Lighting.On80 ||
+                         message.Command == OpenNettyCommands.Lighting.On90 ||
+                         message.Command == OpenNettyCommands.Lighting.On100:
                 {
-                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(address), async (endpoint, cancellationToken) =>
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
                         // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
-                        if (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway)
+                        if (endpoint.Gateway != notification.Gateway)
                         {
                             return;
                         }
 
                         // SCS devices configured to use the PUL mode never react to area and general commands.
-                        if (address.Type is OpenNettyAddressType.ScsLightPoint &&
-                            (OpenNettyAddress.IsScsLightPointAreaAddress(address) ||
-                             OpenNettyAddress.IsScsLightPointGeneralAddress(address)) &&
+                        if (message.Address.Value.Type is OpenNettyAddressType.ScsLightPoint &&
+                            (OpenNettyAddress.IsScsLightPointAreaAddress(message.Address.Value) ||
+                             OpenNettyAddress.IsScsLightPointGeneralAddress(message.Address.Value)) &&
                             endpoint.GetStringSetting(OpenNettySettings.SwitchMode) is OpenNettySettings.SwitchModes.PushButton)
-                        {
-                            return;
-                        }
-
-                        if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState) &&
-                            endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is null or OpenNettySettings.ActuatorTypes.Lighting)
-                        {
-                            await _events.PublishAsync(new SwitchStateReportedEventArgs(endpoint,
-                                command.Value == OpenNettyCommands.Lighting.On.Value ?
-                                    OpenNettyModels.Lighting.SwitchState.On :
-                                    OpenNettyModels.Lighting.SwitchState.Off), cancellationToken);
-                        }
-                    });
-                    break;
-                }
-
-                case (OpenNettyNotifications.MessageReceived,
-                      OpenNettyMessage { Protocol: OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee,
-                                         Type    : OpenNettyMessageType.BusCommand,
-                                         Command : OpenNettyCommand command,
-                                         Address : OpenNettyAddress address })
-                    when command == OpenNettyCommands.Lighting.On20 ||
-                         command == OpenNettyCommands.Lighting.On30 ||
-                         command == OpenNettyCommands.Lighting.On40 ||
-                         command == OpenNettyCommands.Lighting.On50 ||
-                         command == OpenNettyCommands.Lighting.On60 ||
-                         command == OpenNettyCommands.Lighting.On70 ||
-                         command == OpenNettyCommands.Lighting.On80 ||
-                         command == OpenNettyCommands.Lighting.On90 ||
-                         command == OpenNettyCommands.Lighting.On100:
-                {
-                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(address), async (endpoint, cancellationToken) =>
-                    {
-                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
-                        if (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway)
-                        {
-                            return;
-                        }
-
-                        // SCS devices configured to use the PUL mode never react to area and general commands.
-                        if (address.Type is OpenNettyAddressType.ScsLightPoint &&
-                            (OpenNettyAddress.IsScsLightPointAreaAddress(address) ||
-                             OpenNettyAddress.IsScsLightPointGeneralAddress(address)) &&
-                            endpoint.GetStringSetting(OpenNettySettings.SwitchMode) is OpenNettySettings.SwitchModes.PushButton)
-                        {
-                            return;
-                        }
-
-                        if (endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is not (null or OpenNettySettings.ActuatorTypes.Lighting))
                         {
                             return;
                         }
@@ -317,14 +315,14 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                            !endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState))
                         {
                             await _events.PublishAsync(new BrightnessReportedEventArgs(endpoint, (byte)
-                                (command == OpenNettyCommands.Lighting.On20 ? 20 :
-                                 command == OpenNettyCommands.Lighting.On30 ? 30 :
-                                 command == OpenNettyCommands.Lighting.On40 ? 40 :
-                                 command == OpenNettyCommands.Lighting.On50 ? 50 :
-                                 command == OpenNettyCommands.Lighting.On60 ? 60 :
-                                 command == OpenNettyCommands.Lighting.On70 ? 70 :
-                                 command == OpenNettyCommands.Lighting.On80 ? 80 :
-                                 command == OpenNettyCommands.Lighting.On90 ? 90 : 100)), cancellationToken);
+                                (message.Command == OpenNettyCommands.Lighting.On20 ? 20 :
+                                 message.Command == OpenNettyCommands.Lighting.On30 ? 30 :
+                                 message.Command == OpenNettyCommands.Lighting.On40 ? 40 :
+                                 message.Command == OpenNettyCommands.Lighting.On50 ? 50 :
+                                 message.Command == OpenNettyCommands.Lighting.On60 ? 60 :
+                                 message.Command == OpenNettyCommands.Lighting.On70 ? 70 :
+                                 message.Command == OpenNettyCommands.Lighting.On80 ? 80 :
+                                 message.Command == OpenNettyCommands.Lighting.On90 ? 90 : 100)), cancellationToken);
                         }
                     });
                     break;
@@ -342,7 +340,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(address), async (endpoint, cancellationToken) =>
                     {
                         // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
-                        if (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway)
+                        if (endpoint.Gateway != notification.Gateway)
                         {
                             return;
                         }
@@ -352,11 +350,6 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                             (OpenNettyAddress.IsScsLightPointAreaAddress(address) ||
                              OpenNettyAddress.IsScsLightPointGeneralAddress(address)) &&
                             endpoint.GetStringSetting(OpenNettySettings.SwitchMode) is OpenNettySettings.SwitchModes.PushButton)
-                        {
-                            return;
-                        }
-
-                        if (endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is not (null or OpenNettySettings.ActuatorTypes.Lighting))
                         {
                             return;
                         }
@@ -373,10 +366,66 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                         // Note: the special brightness level "0" always indicates that the output is switched off.
                         // To avoid overriding the last known level (which is typically restored by SCS devices when
                         // receiving an ON command), the brightness level is only reported if it's higher than zero.
+                        // 
+                        // Note: while Nitoo devices normally don't restore the last known brightness level when
+                        // receiving an ON command, the same rule applies for consistency with MyHome/SCS devices.
                         if (level is not 0 && (endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) ||
                                                endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState)))
                         {
                             await _events.PublishAsync(new BrightnessReportedEventArgs(endpoint, level), cancellationToken);
+                        }
+                    });
+                    break;
+                }
+
+                case (OpenNettyNotifications.MessageSent,
+                      OpenNettyMessage { Protocol : OpenNettyProtocol.Nitoo or OpenNettyProtocol.Zigbee,
+                                         Type     : OpenNettyMessageType.DimensionSet,
+                                         Address  : OpenNettyAddress address,
+                                         Dimension: OpenNettyDimension dimension,
+                                         Values   : [{ Length: > 0 } value, ..] })
+                    when dimension == OpenNettyDimensions.Lighting.DimmerLevelSpeed:
+                {
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(address), async (endpoint, cancellationToken) =>
+                    {
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
+                        {
+                            return;
+                        }
+
+                        // Note: for Nitoo devices, the brightness level is expressed differently.
+                        var level = message.Protocol is OpenNettyProtocol.Nitoo ?
+                            (byte) (byte.Parse(value, CultureInfo.InvariantCulture) - 100) :
+                            (byte) Math.Round(decimal.Parse(value, CultureInfo.InvariantCulture), MidpointRounding.AwayFromZero);
+
+                        switch (endpoint.Protocol)
+                        {
+                            // Note: outgoing dimmer level commands sent using broadcast or multicast transmission
+                            // generally don't affect the local output of a Nitoo lighting device. As such, the switch
+                            // state/brightness of the endpoint is only reported if the message was sent in unicast.
+                            case OpenNettyProtocol.Nitoo when message.Mode is OpenNettyMode.Unicast:
+                            case OpenNettyProtocol.Zigbee:
+                                if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
+                                {
+                                    await _events.PublishAsync(new SwitchStateReportedEventArgs(endpoint, level is not 0 ?
+                                        OpenNettyModels.Lighting.SwitchState.On :
+                                        OpenNettyModels.Lighting.SwitchState.Off), cancellationToken);
+                                    break;
+                                }
+
+                                // Note: the special brightness level "0" always indicates that the output is switched off.
+                                // To avoid overriding the last known level (which is typically restored by SCS devices when
+                                // receiving an ON command), the brightness level is only reported if it's higher than zero.
+                                // 
+                                // Note: while Nitoo devices normally don't restore the last known brightness level when
+                                // receiving an ON command, the same rule applies for consistency with MyHome/SCS devices.
+                                if (level is not 0 && (endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) ||
+                                                       endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState)))
+                                {
+                                    await _events.PublishAsync(new BrightnessReportedEventArgs(endpoint, level), cancellationToken);
+                                }
+                                break;
                         }
                     });
                     break;
@@ -390,21 +439,21 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Values   : ["129", { Length: > 0 } value] })
                     when dimension == OpenNettyDimensions.Diagnostics.UnitDescription:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(address), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
+                        {
+                            return;
+                        }
 
-                    if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState) &&
-                        endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is null or OpenNettySettings.ActuatorTypes.Lighting)
-                    {
-                        await _events.PublishAsync(new SwitchStateReportedEventArgs(endpoint, value is "128" or "129" or "130" ?
-                            OpenNettyModels.Lighting.SwitchState.On :
-                            OpenNettyModels.Lighting.SwitchState.Off));
-                    }
+                        if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
+                        {
+                            await _events.PublishAsync(new SwitchStateReportedEventArgs(endpoint, value is "128" or "129" or "130" ?
+                                OpenNettyModels.Lighting.SwitchState.On :
+                                OpenNettyModels.Lighting.SwitchState.Off), cancellationToken);
+                        }
+                    });
                     break;
                 }
 
@@ -416,81 +465,35 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Values   : ["143", { Length: > 0 } value, ..] })
                     when dimension == OpenNettyDimensions.Diagnostics.UnitDescription:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
+                        {
+                            return;
+                        }
 
-                    var level = byte.Parse(value, CultureInfo.InvariantCulture);
+                        var level = byte.Parse(value, CultureInfo.InvariantCulture);
 
-                    if (endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is not (null or OpenNettySettings.ActuatorTypes.Lighting))
-                    {
-                        return;
-                    }
+                        if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
+                        {
+                            await _events.PublishAsync(new SwitchStateReportedEventArgs(endpoint, level is not 0 ?
+                                OpenNettyModels.Lighting.SwitchState.On :
+                                OpenNettyModels.Lighting.SwitchState.Off), cancellationToken);
+                        }
 
-                    if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
-                    {
-                        await _events.PublishAsync(new SwitchStateReportedEventArgs(endpoint, level is not 0 ?
-                            OpenNettyModels.Lighting.SwitchState.On :
-                            OpenNettyModels.Lighting.SwitchState.Off));
-                    }
-
-                    // Note: the special brightness level "0" always indicates that the output is switched off.
-                    // While Nitoo devices normally don't restore the last known brightness level, the brightness
-                    // level is only reported if it's higher than zero for consistency with MyHome/SCS devices.
-                    if (level is not 0 && (endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) ||
-                                           endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState)))
-                    {
-                        await _events.PublishAsync(new BrightnessReportedEventArgs(endpoint, level));
-                    }
-                    break;
-                }
-
-                // Note: outgoing dimmer level commands sent using broadcast or multicast transmission
-                // generally don't affect the local output of a Nitoo lighting device. As such, the switch
-                // state/brightness of the endpoint is only reported if the message was sent in unicast.
-                case (OpenNettyNotifications.MessageReceived or OpenNettyNotifications.MessageSent,
-                      OpenNettyMessage { Protocol : OpenNettyProtocol.Nitoo,
-                                         Type     : OpenNettyMessageType.DimensionSet,
-                                         Address  : OpenNettyAddress address,
-                                         Mode     : OpenNettyMode.Unicast,
-                                         Dimension: OpenNettyDimension dimension,
-                                         Values   : [{ Length: > 0 } value, ..] })
-                    when dimension == OpenNettyDimensions.Lighting.DimmerLevelSpeed:
-                {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
-                    {
-                        return;
-                    }
-
-                    if (endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is not (null or OpenNettySettings.ActuatorTypes.Lighting))
-                    {
-                        return;
-                    }
-
-                    var level = (byte) Math.Round(decimal.Parse(value, CultureInfo.InvariantCulture), MidpointRounding.AwayFromZero);
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
-                    {
-                        await _events.PublishAsync(new SwitchStateReportedEventArgs(endpoint, level is not 0 ?
-                            OpenNettyModels.Lighting.SwitchState.On :
-                            OpenNettyModels.Lighting.SwitchState.Off));
-                    }
-
-                    // Note: the special brightness level "0" always indicates that the output is switched off.
-                    // While Nitoo devices normally don't restore the last known brightness level, the brightness
-                    // level is only reported if it's higher than zero for consistency with MyHome/SCS devices.
-                    if (level is not 0 && (endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) ||
-                                           endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState)))
-                    {
-                        await _events.PublishAsync(new BrightnessReportedEventArgs(endpoint, level));
-                    }
+                        // Note: the special brightness level "0" always indicates that the output is switched off.
+                        // To avoid overriding the last known level (which is typically restored by SCS devices when
+                        // receiving an ON command), the brightness level is only reported if it's higher than zero.
+                        // 
+                        // Note: while Nitoo devices normally don't restore the last known brightness level when
+                        // receiving an ON command, the same rule applies for consistency with MyHome/SCS devices.
+                        if (level is not 0 && (endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) ||
+                                               endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState)))
+                        {
+                            await _events.PublishAsync(new BrightnessReportedEventArgs(endpoint, level), cancellationToken);
+                        }
+                    });
                     break;
                 }
 
@@ -501,160 +504,142 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Address : OpenNettyAddress address })
                     when command == OpenNettyCommands.Lighting.Toggle:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
-                    {
-                        return;
-                    }
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.ToggleScenarioState))
-                    {
-                        await _events.PublishAsync(new ToggleScenarioReportedEventArgs(endpoint));
-                    }
-                    break;
-                }
-
-                // The shutter state and the position of an endpoint can be inferred from 4 types of messages:
-                //
-                //   - For Nitoo devices, from an incoming or outgoing "STOP", "UP" or "DOWN" BUS COMMAND message.
-                //   - For SCS/Zigbee devices, from an incoming "STOP", "UP" or "DOWN" BUS COMMAND message.
-                //   - For SCS/Zigbee devices, from an incoming "SHUTTER STATUS" DIMENSION READ message.
-                //   - For Nitoo devices, from an incoming "UNIT DESCRIPTION" DIMENSION READ message.
-
-                case (OpenNettyNotification notification,
-                      OpenNettyMessage { Protocol: OpenNettyProtocol.Nitoo,
-                                         Type    : OpenNettyMessageType.BusCommand,
-                                         Command : OpenNettyCommand command,
-                                         Address : OpenNettyAddress address,
-                                         Mode    : OpenNettyMode mode })
-                    when command == OpenNettyCommands.Automation.Stop ||
-                         command == OpenNettyCommands.Automation.Up   ||
-                         command == OpenNettyCommands.Automation.Down:
-                {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
-                    {
-                        return;
-                    }
-
-                    // If the message was received and was emitted by the source using a
-                    // broadcast transmission, it is considered as an STOP/UP/DOWN scenario.
-                    if (notification is OpenNettyNotifications.MessageReceived && mode is OpenNettyMode.Broadcast &&
-                        endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioState))
-                    {
-                        if (command == OpenNettyCommands.Automation.Stop)
-                        {
-                            await _events.PublishAsync(new ShutterStopScenarioReportedEventArgs(endpoint));
-                        }
-
-                        else if (command == OpenNettyCommands.Automation.Up)
-                        {
-                            await _events.PublishAsync(new ShutterUpScenarioReportedEventArgs(endpoint));
-                        }
-
-                        else
-                        {
-                            await _events.PublishAsync(new ShutterDownScenarioReportedEventArgs(endpoint));
-                        }
-                    }
-
-                    List<Task> tasks = [];
-
-                    // Note: outgoing STOP/UP/DOWN commands sent using broadcast or multicast transmission
-                    // generally don't affect the local output of a Nitoo automation device. As such,
-                    // the shutter state/position of the endpoint is only reported if the message was
-                    // received (e.g by a different unit on the same device) or was sent in unicast.
-                    if (mode is OpenNettyMode.Unicast || notification is OpenNettyNotifications.MessageReceived)
-                    {
-                        if (endpoint.HasCapability(OpenNettyCapabilities.BasicShutterState) &&
-                            endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is null or OpenNettySettings.ActuatorTypes.Automation)
-                        {
-                            tasks.Add(ReportStateAsync(endpoint, CancellationToken.None).AsTask());
-                        }
-
-                        if (endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit.Definition.AssociatedUnitId: byte unit })
-                        {
-                            tasks.Add(Task.Run(async () =>
-                            {
-                                var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
-                                    OpenNettyAddress.ToNitooAddress(address).Identifier, unit));
-
-                                if (endpoint is not null &&
-                                    endpoint.HasCapability(OpenNettyCapabilities.BasicShutterState) &&
-                                    endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is null or OpenNettySettings.ActuatorTypes.Automation)
-                                {
-                                    await ReportStateAsync(endpoint, CancellationToken.None);
-                                }
-                            }));
-                        }
-                    }
-
-                    if (mode is OpenNettyMode.Broadcast or OpenNettyMode.Multicast && endpoint is { Unit.Scenarios: [_, ..] scenarios })
-                    {
-                        var endpoints = scenarios.ToAsyncEnumerable()
-                            .Where(static scenario => scenario.FunctionCode is < 110 or 111 or 112)
-                            .SelectAwait(scenario => _manager.FindEndpointByNameAsync(scenario.EndpointName))
-                            .Where(static endpoint => endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit: OpenNettyUnit })
-                            .OfType<OpenNettyEndpoint>()
-                            .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.BasicShutterState));
-
-                        tasks.Add(Parallel.ForEachAsync(endpoints, ReportStateAsync));
-                    }
-
-                    await Task.WhenAll(tasks);
-
-                    async ValueTask ReportStateAsync(OpenNettyEndpoint endpoint, CancellationToken cancellationToken)
-                        => await _events.PublishAsync(new ShutterStateReportedEventArgs(endpoint,
-                            command == OpenNettyCommands.Automation.Stop ? OpenNettyModels.Automation.ShutterState.Stopped :
-                            command == OpenNettyCommands.Automation.Up   ? OpenNettyModels.Automation.ShutterState.Opening :
-                            command == OpenNettyCommands.Automation.Down ? OpenNettyModels.Automation.ShutterState.Closing :
-                            throw new InvalidDataException(SR.GetResourceString(SR.ID0075))), cancellationToken);
-                    break;
-                }
-
-                case (OpenNettyNotifications.MessageReceived,
-                      OpenNettyMessage { Protocol: OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee,
-                                         Type    : OpenNettyMessageType.BusCommand,
-                                         Command : OpenNettyCommand command,
-                                         Address : OpenNettyAddress address })
-                    when command == OpenNettyCommands.Automation.Stop ||
-                         command == OpenNettyCommands.Automation.Up   ||
-                         command == OpenNettyCommands.Automation.Down:
-                {
-                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(address), async (endpoint, cancellationToken) =>
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
                         // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
-                        if (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway)
+                        if (endpoint.Gateway != notification.Gateway)
                         {
                             return;
                         }
 
-                        if (endpoint is null || !endpoint.HasCapability(OpenNettyCapabilities.BasicShutterState) ||
-                            endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is not (null or OpenNettySettings.ActuatorTypes.Automation))
+                        if (endpoint.HasCapability(OpenNettyCapabilities.ToggleScenarioState))
                         {
-                            return;
-                        }
-
-                        // Note: the STOP command is only reported if the endpoint isn't an advanced shutter.
-                        if (command != OpenNettyCommands.Automation.Stop || !endpoint.HasCapability(OpenNettyCapabilities.AdvancedShutterState))
-                        {
-                            await _events.PublishAsync(new ShutterStateReportedEventArgs(endpoint,
-                                command == OpenNettyCommands.Automation.Stop ? OpenNettyModels.Automation.ShutterState.Stopped :
-                                command == OpenNettyCommands.Automation.Up   ? OpenNettyModels.Automation.ShutterState.Opening :
-                                command == OpenNettyCommands.Automation.Down ? OpenNettyModels.Automation.ShutterState.Closing :
-                                throw new InvalidDataException(SR.GetResourceString(SR.ID0075))), cancellationToken);
+                            await _events.PublishAsync(new ToggleScenarioReportedEventArgs(endpoint), cancellationToken);
                         }
                     });
                     break;
                 }
 
+                // The shutter state and the position of an endpoint can be inferred from 3 types of messages:
+                //
+                //   - From an incoming or outgoing "STOP", "UP" or "DOWN" BUS COMMAND message:
+                //     * For Nitoo and Zigbee devices, the message MAY be incoming or outgoing.
+                //     * For SCS devices, the message MUST be incoming.
+                //
+                //   - For SCS and Zigbee devices, from an incoming "SHUTTER STATUS" DIMENSION READ message.
+                //   - For Nitoo devices, from an incoming "UNIT DESCRIPTION=139" DIMENSION READ message.
+
+                case (OpenNettyNotifications.MessageReceived or OpenNettyNotifications.MessageSent,
+                      OpenNettyMessage { Protocol: OpenNettyProtocol.Nitoo or OpenNettyProtocol.Zigbee,
+                                         Type    : OpenNettyMessageType.BusCommand,
+                                         Command : OpenNettyCommand,
+                                         Address : not null }) or
+                     (OpenNettyNotifications.MessageReceived,
+                      OpenNettyMessage { Protocol: OpenNettyProtocol.Scs,
+                                         Type    : OpenNettyMessageType.BusCommand,
+                                         Command : OpenNettyCommand,
+                                         Address : not null })
+                    when message.Command == OpenNettyCommands.Automation.Stop ||
+                         message.Command == OpenNettyCommands.Automation.Up   ||
+                         message.Command == OpenNettyCommands.Automation.Down:
+                {
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
+                    {
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
+                        {
+                            return;
+                        }
+
+                        List<Task> tasks = [];
+
+                        switch (endpoint.Protocol)
+                        {
+                            // Note: outgoing STOP/UP/DOWN commands sent using broadcast or multicast transmission
+                            // generally don't affect the local output of a Nitoo automation device. As such,
+                            // the shutter state/position of the endpoint is only reported if the message was
+                            // received (e.g by a different unit on the same device) or was sent in unicast.
+                            case OpenNettyProtocol.Nitoo when notification is OpenNettyNotifications.MessageReceived:
+                            case OpenNettyProtocol.Nitoo when notification is OpenNettyNotifications.MessageSent && message.Mode is OpenNettyMode.Unicast:
+                            case OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee:
+                                if (endpoint.HasCapability(OpenNettyCapabilities.BasicShutterState))
+                                {
+                                    tasks.Add(ReportStateAsync(endpoint, cancellationToken).AsTask());
+                                }
+                                break;
+                        }
+
+                        // For Nitoo devices, if the STOP/UP/DOWN command was emitted by a different
+                        // unit on the same device, reflect the state change on the linked endpoint.
+                        if (notification is OpenNettyNotifications.MessageReceived &&
+                            endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit.Definition.AssociatedUnitId: byte unit })
+                        {
+                            tasks.Add(Task.Run(async () =>
+                            {
+                                var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
+                                    OpenNettyAddress.ToNitooAddress(message.Address.Value).Identifier, unit));
+
+                                if (endpoint is not null && endpoint.HasCapability(OpenNettyCapabilities.BasicShutterState))
+                                {
+                                    await ReportStateAsync(endpoint, cancellationToken);
+                                }
+                            }, cancellationToken));
+                        }
+
+                        // For Nitoo devices, if the message was sent using a broadcast or multicast transmission,
+                        // reflect the state change on all the other endpoints that are part of the same scenario.
+                        if (notification is OpenNettyNotifications.MessageReceived &&
+                            message.Mode is OpenNettyMode.Broadcast or OpenNettyMode.Multicast &&
+                            endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit.Scenarios: [_, ..] scenarios })
+                        {
+                            var endpoints = scenarios.ToAsyncEnumerable()
+                                .Where(static scenario => scenario.FunctionCode is < 110 or 111 or 112)
+                                .SelectAwait(scenario => _manager.FindEndpointByNameAsync(scenario.EndpointName))
+                                .Where(static endpoint => endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit: OpenNettyUnit })
+                                .OfType<OpenNettyEndpoint>()
+                                .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.BasicShutterState));
+
+                            tasks.Add(Parallel.ForEachAsync(endpoints, ReportStateAsync));
+                        }
+
+                        // If the message was received and was emitted by the source using a
+                        // broadcast transmission, it is also considered an STOP/UP/DOWN scenario.
+                        if (notification is OpenNettyNotifications.MessageReceived &&
+                            message.Protocol is OpenNettyProtocol.Nitoo &&
+                            message.Mode is OpenNettyMode.Broadcast &&
+                            endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioState))
+                        {
+                            if (message.Command == OpenNettyCommands.Automation.Stop)
+                            {
+                                tasks.Add(_events.PublishAsync(new ShutterStopScenarioReportedEventArgs(endpoint), cancellationToken).AsTask());
+                            }
+
+                            else if (message.Command == OpenNettyCommands.Automation.Up)
+                            {
+                                tasks.Add(_events.PublishAsync(new ShutterUpScenarioReportedEventArgs(endpoint), cancellationToken).AsTask());
+                            }
+
+                            else
+                            {
+                                tasks.Add(_events.PublishAsync(new ShutterDownScenarioReportedEventArgs(endpoint), cancellationToken).AsTask());
+                            }
+                        }
+
+                        await Task.WhenAll(tasks);
+                    });
+
+                    async ValueTask ReportStateAsync(OpenNettyEndpoint endpoint, CancellationToken cancellationToken)
+                        => await _events.PublishAsync(new ShutterStateReportedEventArgs(endpoint,
+                            message.Command == OpenNettyCommands.Automation.Stop ? OpenNettyModels.Automation.ShutterState.Stopped :
+                            message.Command == OpenNettyCommands.Automation.Up   ? OpenNettyModels.Automation.ShutterState.Opening :
+                            message.Command == OpenNettyCommands.Automation.Down ? OpenNettyModels.Automation.ShutterState.Closing :
+                            throw new InvalidDataException(SR.GetResourceString(SR.ID0075))), cancellationToken);
+                    break;
+                }
+
                 case (OpenNettyNotifications.MessageReceived,
-                      OpenNettyMessage { Protocol : OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee,
-                                         Type     : OpenNettyMessageType.DimensionRead,
+                      OpenNettyMessage { Protocol : OpenNettyProtocol.Zigbee,
+                                         Type     : OpenNettyMessageType.DimensionSet,
                                          Address  : OpenNettyAddress address,
                                          Dimension: OpenNettyDimension dimension,
                                          Values   : [{ Length: > 0 } status, { Length: > 0 } position, ..] })
@@ -663,7 +648,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(address), async (endpoint, cancellationToken) =>
                     {
                         // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
-                        if (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway)
+                        if (endpoint.Gateway != notification.Gateway)
                         {
                             return;
                         }
@@ -699,24 +684,24 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Values   : ["139", { Length: > 0 } value, ..] })
                     when dimension == OpenNettyDimensions.Diagnostics.UnitDescription:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.BasicShutterState) &&
-                        endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is not (null or OpenNettySettings.ActuatorTypes.Automation))
-                    {
-                        await _events.PublishAsync(new ShutterStateReportedEventArgs(endpoint, value switch
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
                         {
-                            "100" or "102" => OpenNettyModels.Automation.ShutterState.Opening,
-                            "0"   or "103" => OpenNettyModels.Automation.ShutterState.Closing,
-                                  _        => OpenNettyModels.Automation.ShutterState.Stopped
-                        }));
-                    }
+                            return;
+                        }
+
+                        if (endpoint.HasCapability(OpenNettyCapabilities.BasicShutterState))
+                        {
+                            await _events.PublishAsync(new ShutterStateReportedEventArgs(endpoint, value switch
+                            {
+                                "100" or "102" => OpenNettyModels.Automation.ShutterState.Opening,
+                                "0"   or "103" => OpenNettyModels.Automation.ShutterState.Closing,
+                                      _        => OpenNettyModels.Automation.ShutterState.Stopped
+                            }), cancellationToken);
+                        }
+                    });
                     break;
                 }
 
@@ -728,19 +713,20 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Values   : [{ Length: > 0 }, { Length: > 0 }, { Length: > 0 }] values })
                     when dimension == OpenNettyDimensions.TemperatureControl.SmartMeterIndexes:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
+                        {
+                            return;
+                        }
 
-                    if (endpoint.HasCapability(OpenNettyCapabilities.SmartMeterIndexes))
-                    {
-                        await _events.PublishAsync(new SmartMeterIndexesReportedEventArgs(endpoint,
-                            OpenNettyModels.TemperatureControl.SmartMeterIndexes.CreateFromDimensionValues(values)));
-                    }
+                        if (endpoint.HasCapability(OpenNettyCapabilities.SmartMeterIndexes))
+                        {
+                            await _events.PublishAsync(new SmartMeterIndexesReportedEventArgs(endpoint,
+                                OpenNettyModels.TemperatureControl.SmartMeterIndexes.CreateFromDimensionValues(values)), cancellationToken);
+                        }
+                    });
                     break;
                 }
 
@@ -752,24 +738,25 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Values   : [{ Length: > 0 } value] })
                     when dimension == OpenNettyDimensions.TemperatureControl.SmartMeterRateType:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.SmartMeterInformation))
-                    {
-                        await _events.PublishAsync(new SmartMeterRateTypeReportedEventArgs(endpoint, value switch
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
                         {
-                            "2" => OpenNettyModels.TemperatureControl.SmartMeterRateType.OffPeak,
-                            "3" => OpenNettyModels.TemperatureControl.SmartMeterRateType.Peak,
+                            return;
+                        }
 
-                            _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0075))
-                        }));
-                    }
+                        if (endpoint.HasCapability(OpenNettyCapabilities.SmartMeterInformation))
+                        {
+                            await _events.PublishAsync(new SmartMeterRateTypeReportedEventArgs(endpoint, value switch
+                            {
+                                "2" => OpenNettyModels.TemperatureControl.SmartMeterRateType.OffPeak,
+                                "3" => OpenNettyModels.TemperatureControl.SmartMeterRateType.Peak,
+
+                                _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0075))
+                            }), cancellationToken);
+                        }
+                    });
                     break;
                 }
 
@@ -781,26 +768,27 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Values   : ["7", { Length: > 0 } value] })
                     when dimension == OpenNettyDimensions.Diagnostics.UnitDescription:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.SmartMeterInformation))
-                    {
-                        await _events.PublishAsync(new SmartMeterRateTypeReportedEventArgs(endpoint, value switch
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
                         {
-                            "32" or "33" => OpenNettyModels.TemperatureControl.SmartMeterRateType.OffPeak,
-                            "48" or "49" => OpenNettyModels.TemperatureControl.SmartMeterRateType.Peak,
+                            return;
+                        }
 
-                            _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0075))
-                        }));
+                        if (endpoint.HasCapability(OpenNettyCapabilities.SmartMeterInformation))
+                        {
+                            await _events.PublishAsync(new SmartMeterRateTypeReportedEventArgs(endpoint, value switch
+                            {
+                                "32" or "33" => OpenNettyModels.TemperatureControl.SmartMeterRateType.OffPeak,
+                                "48" or "49" => OpenNettyModels.TemperatureControl.SmartMeterRateType.Peak,
 
-                        await _events.PublishAsync(new SmartMeterPowerCutModeReportedEventArgs(endpoint, value is "33" or "49"));
-                    }
+                                _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0075))
+                            }), cancellationToken);
+
+                            await _events.PublishAsync(new SmartMeterPowerCutModeReportedEventArgs(endpoint, value is "33" or "49"), cancellationToken);
+                        }
+                    });
                     break;
                 }
 
@@ -812,58 +800,59 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Values   : ["133", { Length: > 0 } value] })
                     when dimension == OpenNettyDimensions.Diagnostics.UnitDescription:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.WaterHeating))
-                    {
-                        switch (value)
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
                         {
-                            // Note: the value "0" is ambiguous and appears to be used to represent two cases:
-                            //
-                            //  - When the user selected the "automatic" mode but hot water is not currently
-                            //    being produced (e.g because the off-peak signal was not yet received).
-                            //
-                            //  - When no hot water is produced because the user selected the "forced off" mode.
-                            //
-                            // Since the value is ambiguous, it is not possible to reliably determine the actual
-                            // water heating mode: in this case, the mode is not immediately reported and an another
-                            // event handler is responsible for reporting it when the off-peak signal is received.
-                            case "0":
-                                await _events.PublishAsync(new WaterHeaterStateReportedEventArgs(endpoint,
-                                    OpenNettyModels.TemperatureControl.WaterHeaterState.Idle));
-                                break;
-
-                            case "32":
-                                await _events.PublishAsync(new WaterHeaterSetpointModeReportedEventArgs(endpoint,
-                                    OpenNettyModels.TemperatureControl.WaterHeaterMode.Automatic));
-
-                                await _events.PublishAsync(new WaterHeaterStateReportedEventArgs(endpoint,
-                                    OpenNettyModels.TemperatureControl.WaterHeaterState.Idle));
-                                break;
-
-                            case "1" or "33":
-                                await _events.PublishAsync(new WaterHeaterSetpointModeReportedEventArgs(endpoint,
-                                    OpenNettyModels.TemperatureControl.WaterHeaterMode.Automatic));
-
-                                await _events.PublishAsync(new WaterHeaterStateReportedEventArgs(endpoint,
-                                    OpenNettyModels.TemperatureControl.WaterHeaterState.Heating));
-                                break;
-
-                            case "17":
-                                await _events.PublishAsync(new WaterHeaterSetpointModeReportedEventArgs(endpoint,
-                                    OpenNettyModels.TemperatureControl.WaterHeaterMode.ForcedOn));
-
-                                await _events.PublishAsync(new WaterHeaterStateReportedEventArgs(endpoint,
-                                    OpenNettyModels.TemperatureControl.WaterHeaterState.Heating));
-                                break;
+                            return;
                         }
-                    }
+
+                        if (endpoint.HasCapability(OpenNettyCapabilities.WaterHeating))
+                        {
+                            switch (value)
+                            {
+                                // Note: the value "0" is ambiguous and appears to be used to represent two cases:
+                                //
+                                //  - When the user selected the "automatic" mode but hot water is not currently
+                                //    being produced (e.g because the off-peak signal was not yet received).
+                                //
+                                //  - When no hot water is produced because the user selected the "forced off" mode.
+                                //
+                                // Since the value is ambiguous, it is not possible to reliably determine the actual
+                                // water heating mode: in this case, the mode is not immediately reported and an another
+                                // event handler is responsible for reporting it when the off-peak signal is received.
+                                case "0":
+                                    await _events.PublishAsync(new WaterHeaterStateReportedEventArgs(endpoint,
+                                        OpenNettyModels.TemperatureControl.WaterHeaterState.Idle), cancellationToken);
+                                    break;
+
+                                case "32":
+                                    await _events.PublishAsync(new WaterHeaterSetpointModeReportedEventArgs(endpoint,
+                                        OpenNettyModels.TemperatureControl.WaterHeaterMode.Automatic), cancellationToken);
+
+                                    await _events.PublishAsync(new WaterHeaterStateReportedEventArgs(endpoint,
+                                        OpenNettyModels.TemperatureControl.WaterHeaterState.Idle), cancellationToken);
+                                    break;
+
+                                case "1" or "33":
+                                    await _events.PublishAsync(new WaterHeaterSetpointModeReportedEventArgs(endpoint,
+                                        OpenNettyModels.TemperatureControl.WaterHeaterMode.Automatic), cancellationToken);
+
+                                    await _events.PublishAsync(new WaterHeaterStateReportedEventArgs(endpoint,
+                                        OpenNettyModels.TemperatureControl.WaterHeaterState.Heating), cancellationToken);
+                                    break;
+
+                                case "17":
+                                    await _events.PublishAsync(new WaterHeaterSetpointModeReportedEventArgs(endpoint,
+                                        OpenNettyModels.TemperatureControl.WaterHeaterMode.ForcedOn), cancellationToken);
+
+                                    await _events.PublishAsync(new WaterHeaterStateReportedEventArgs(endpoint,
+                                        OpenNettyModels.TemperatureControl.WaterHeaterState.Heating), cancellationToken);
+                                    break;
+                            }
+                        }
+                    });
                     break;
                 }
 
@@ -876,48 +865,49 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Values   : [{ Length: > 0 } value, ..] })
                     when dimension == OpenNettyDimensions.TemperatureControl.WaterHeatingMode:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
-
-                    List<Task> tasks = [];
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.WaterHeating))
-                    {
-                        tasks.Add(ReportSetpointModeAsync(endpoint, CancellationToken.None).AsTask());
-                    }
-
-                    if (endpoint is { Unit.Definition.AssociatedUnitId: byte unit })
-                    {
-                        tasks.Add(Task.Run(async () =>
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
                         {
-                            var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
-                                OpenNettyAddress.ToNitooAddress(address).Identifier, unit));
+                            return;
+                        }
 
-                            if (endpoint is not null && endpoint.HasCapability(OpenNettyCapabilities.WaterHeating))
+                        List<Task> tasks = [];
+
+                        if (endpoint.HasCapability(OpenNettyCapabilities.WaterHeating))
+                        {
+                            tasks.Add(ReportSetpointModeAsync(endpoint, cancellationToken).AsTask());
+                        }
+
+                        if (endpoint is { Unit.Definition.AssociatedUnitId: byte unit })
+                        {
+                            tasks.Add(Task.Run(async () =>
                             {
-                                await ReportSetpointModeAsync(endpoint, CancellationToken.None);
-                            }
-                        }));
-                    }
+                                var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
+                                    OpenNettyAddress.ToNitooAddress(address).Identifier, unit));
 
-                    if (mode is OpenNettyMode.Broadcast or OpenNettyMode.Multicast && endpoint is { Unit.Scenarios: [_, ..] scenarios })
-                    {
-                        var endpoints = scenarios.ToAsyncEnumerable()
-                            .Where(static scenario => scenario.FunctionCode is 255)
-                            .SelectAwait(scenario => _manager.FindEndpointByNameAsync(scenario.EndpointName))
-                            .Where(static endpoint => endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit: OpenNettyUnit })
-                            .OfType<OpenNettyEndpoint>()
-                            .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.WaterHeating));
+                                if (endpoint is not null && endpoint.HasCapability(OpenNettyCapabilities.WaterHeating))
+                                {
+                                    await ReportSetpointModeAsync(endpoint, cancellationToken);
+                                }
+                            }, cancellationToken));
+                        }
 
-                        tasks.Add(Parallel.ForEachAsync(endpoints, ReportSetpointModeAsync));
-                    }
+                        if (mode is OpenNettyMode.Broadcast or OpenNettyMode.Multicast && endpoint is { Unit.Scenarios: [_, ..] scenarios })
+                        {
+                            var endpoints = scenarios.ToAsyncEnumerable()
+                                .Where(static scenario => scenario.FunctionCode is 255)
+                                .SelectAwait(scenario => _manager.FindEndpointByNameAsync(scenario.EndpointName))
+                                .Where(static endpoint => endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit: OpenNettyUnit })
+                                .OfType<OpenNettyEndpoint>()
+                                .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.WaterHeating));
 
-                    await Task.WhenAll(tasks);
+                            tasks.Add(Parallel.ForEachAsync(endpoints, ReportSetpointModeAsync));
+                        }
+
+                        await Task.WhenAll(tasks);
+                    });
 
                     async ValueTask ReportSetpointModeAsync(OpenNettyEndpoint endpoint, CancellationToken cancellationToken) =>
                         await _events.PublishAsync(new WaterHeaterSetpointModeReportedEventArgs(endpoint, value switch
@@ -946,83 +936,84 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Values   : ["6" or "132", { Length: > 0 } value] })
                     when dimension == OpenNettyDimensions.Diagnostics.UnitDescription:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
-                    {
-                        var configuration = OpenNettyModels.TemperatureControl.PilotWireConfiguration.CreateFromUnitDescription([value]);
-                        if (configuration.IsDerogationActive)
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
                         {
-                            await _events.PublishAsync(new PilotWireDerogationModeReportedEventArgs(endpoint, configuration.Mode, configuration.DerogationDuration));
+                            return;
                         }
 
-                        else
+                        if (endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
                         {
-                            await _events.PublishAsync(new PilotWireSetpointModeReportedEventArgs(endpoint, configuration.Mode));
-                            await _events.PublishAsync(new PilotWireDerogationModeReportedEventArgs(endpoint, null, null));
+                            var configuration = OpenNettyModels.TemperatureControl.PilotWireConfiguration.CreateFromUnitDescription([value]);
+                            if (configuration.IsDerogationActive)
+                            {
+                                await _events.PublishAsync(new PilotWireDerogationModeReportedEventArgs(endpoint, configuration.Mode, configuration.DerogationDuration), cancellationToken);
+                            }
+
+                            else
+                            {
+                                await _events.PublishAsync(new PilotWireSetpointModeReportedEventArgs(endpoint, configuration.Mode), cancellationToken);
+                                await _events.PublishAsync(new PilotWireDerogationModeReportedEventArgs(endpoint, null, null), cancellationToken);
+                            }
                         }
-                    }
+                    });
                     break;
                 }
 
-                case (OpenNettyNotification notification,
+                case (OpenNettyNotifications.MessageReceived or OpenNettyNotifications.MessageSent,
                       OpenNettyMessage { Protocol : OpenNettyProtocol.Nitoo,
                                          Type     : OpenNettyMessageType.BusCommand,
                                          Command  : OpenNettyCommand command,
                                          Address  : OpenNettyAddress address,
                                          Mode     : OpenNettyMode mode })
-                    when command.Category   == OpenNettyCategories.TemperatureControl                           &&
-                         command.Value      == OpenNettyCommands.TemperatureControl.WirePilotSetpointMode.Value &&
+                    when command.WithParameters([]) == OpenNettyCommands.TemperatureControl.WirePilotSetpointMode &&
                          command.Parameters is [{ Length: > 0 } value]:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
-
-                    List<Task> tasks = [];
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
-                    {
-                        tasks.Add(ReportSetpointModeAsync(endpoint, CancellationToken.None).AsTask());
-                    }
-
-                    if (endpoint is { Unit.Definition.AssociatedUnitId: byte unit })
-                    {
-                        tasks.Add(Task.Run(async () =>
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
                         {
-                            var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
-                                OpenNettyAddress.ToNitooAddress(address).Identifier, unit));
+                            return;
+                        }
 
-                            if (endpoint is not null && endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
+                        List<Task> tasks = [];
+
+                        if (endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
+                        {
+                            tasks.Add(ReportSetpointModeAsync(endpoint, cancellationToken).AsTask());
+                        }
+
+                        if (endpoint is { Unit.Definition.AssociatedUnitId: byte unit })
+                        {
+                            tasks.Add(Task.Run(async () =>
                             {
-                                await ReportSetpointModeAsync(endpoint, CancellationToken.None);
-                            }
-                        }));
-                    }
+                                var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
+                                    OpenNettyAddress.ToNitooAddress(address).Identifier, unit));
 
-                    if (mode is OpenNettyMode.Broadcast or OpenNettyMode.Multicast && endpoint is { Unit.Scenarios: [_, ..] scenarios })
-                    {
-                        var endpoints = scenarios.ToAsyncEnumerable()
-                            .Where(static scenario => scenario.FunctionCode is 255)
-                            .SelectAwait(scenario => _manager.FindEndpointByNameAsync(scenario.EndpointName))
-                            .Where(static endpoint => endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit: OpenNettyUnit })
-                            .OfType<OpenNettyEndpoint>()
-                            .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating));
+                                if (endpoint is not null && endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
+                                {
+                                    await ReportSetpointModeAsync(endpoint, cancellationToken);
+                                }
+                            }, cancellationToken));
+                        }
 
-                        tasks.Add(Parallel.ForEachAsync(endpoints, ReportSetpointModeAsync));
-                    }
+                        if (mode is OpenNettyMode.Broadcast or OpenNettyMode.Multicast && endpoint is { Unit.Scenarios: [_, ..] scenarios })
+                        {
+                            var endpoints = scenarios.ToAsyncEnumerable()
+                                .Where(static scenario => scenario.FunctionCode is 255)
+                                .SelectAwait(scenario => _manager.FindEndpointByNameAsync(scenario.EndpointName))
+                                .Where(static endpoint => endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit: OpenNettyUnit })
+                                .OfType<OpenNettyEndpoint>()
+                                .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating));
 
-                    await Task.WhenAll(tasks);
+                            tasks.Add(Parallel.ForEachAsync(endpoints, ReportSetpointModeAsync));
+                        }
+
+                        await Task.WhenAll(tasks);
+                    });
 
                     // Note: setting the setpoint mode may not have an immediate effect on the device (e.g if a
                     // derogation mode was set with a minimal duration during which setpoint commands are ignored).
@@ -1048,52 +1039,52 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Command  : OpenNettyCommand command,
                                          Address  : OpenNettyAddress address,
                                          Mode     : OpenNettyMode mode })
-                    when command.Category   == OpenNettyCategories.TemperatureControl                             &&
-                         command.Value      == OpenNettyCommands.TemperatureControl.WirePilotDerogationMode.Value &&
+                    when command.WithParameters([]) == OpenNettyCommands.TemperatureControl.WirePilotDerogationMode &&
                          command.Parameters is [{ Length: > 0 } value]:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
-
-                    List<Task> tasks = [];
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
-                    {
-                        tasks.Add(ReportDerogationModeAsync(endpoint, CancellationToken.None).AsTask());
-                    }
-
-                    if (endpoint is { Unit.Definition.AssociatedUnitId: byte unit })
-                    {
-                        tasks.Add(Task.Run(async () =>
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
                         {
-                            var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
-                                OpenNettyAddress.ToNitooAddress(address).Identifier, unit));
+                            return;
+                        }
 
-                            if (endpoint is not null && endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
+                        List<Task> tasks = [];
+
+                        if (endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
+                        {
+                            tasks.Add(ReportDerogationModeAsync(endpoint, cancellationToken).AsTask());
+                        }
+
+                        if (endpoint is { Unit.Definition.AssociatedUnitId: byte unit })
+                        {
+                            tasks.Add(Task.Run(async () =>
                             {
-                                await ReportDerogationModeAsync(endpoint, CancellationToken.None);
-                            }
-                        }));
-                    }
+                                var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
+                                    OpenNettyAddress.ToNitooAddress(address).Identifier, unit));
 
-                    if (mode is OpenNettyMode.Broadcast or OpenNettyMode.Multicast && endpoint is { Unit.Scenarios: [_, ..] scenarios })
-                    {
-                        var endpoints = scenarios.ToAsyncEnumerable()
-                            .Where(static scenario => scenario.FunctionCode is 255)
-                            .SelectAwait(scenario => _manager.FindEndpointByNameAsync(scenario.EndpointName))
-                            .Where(static endpoint => endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit: OpenNettyUnit })
-                            .OfType<OpenNettyEndpoint>()
-                            .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating));
+                                if (endpoint is not null && endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
+                                {
+                                    await ReportDerogationModeAsync(endpoint, cancellationToken);
+                                }
+                            }, cancellationToken));
+                        }
 
-                        tasks.Add(Parallel.ForEachAsync(endpoints, ReportDerogationModeAsync));
-                    }
+                        if (mode is OpenNettyMode.Broadcast or OpenNettyMode.Multicast && endpoint is { Unit.Scenarios: [_, ..] scenarios })
+                        {
+                            var endpoints = scenarios.ToAsyncEnumerable()
+                                .Where(static scenario => scenario.FunctionCode is 255)
+                                .SelectAwait(scenario => _manager.FindEndpointByNameAsync(scenario.EndpointName))
+                                .Where(static endpoint => endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit: OpenNettyUnit })
+                                .OfType<OpenNettyEndpoint>()
+                                .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating));
 
-                    await Task.WhenAll(tasks);
+                            tasks.Add(Parallel.ForEachAsync(endpoints, ReportDerogationModeAsync));
+                        }
+
+                        await Task.WhenAll(tasks);
+                    });
 
                     async ValueTask ReportDerogationModeAsync(OpenNettyEndpoint endpoint, CancellationToken cancellationToken) =>
                         await _events.PublishAsync(new PilotWireDerogationModeReportedEventArgs(endpoint,
@@ -1124,51 +1115,52 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Mode     : OpenNettyMode mode })
                     when command == OpenNettyCommands.TemperatureControl.CancelWirePilotDerogationMode:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
-
-                    List<Task> tasks = [];
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
-                    {
-                        tasks.Add(_events.PublishAsync(new PilotWireDerogationModeReportedEventArgs(endpoint, null, null)).AsTask());
-                    }
-
-                    if (endpoint is { Unit.Definition.AssociatedUnitId: byte unit })
-                    {
-                        tasks.Add(Task.Run(async () =>
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
                         {
-                            var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
-                                OpenNettyAddress.ToNitooAddress(address).Identifier, unit));
+                            return;
+                        }
 
-                            if (endpoint is not null && endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
+                        List<Task> tasks = [];
+
+                        if (endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
+                        {
+                            tasks.Add(_events.PublishAsync(new PilotWireDerogationModeReportedEventArgs(endpoint, null, null), cancellationToken).AsTask());
+                        }
+
+                        if (endpoint is { Unit.Definition.AssociatedUnitId: byte unit })
+                        {
+                            tasks.Add(Task.Run(async () =>
                             {
-                                await _events.PublishAsync(new PilotWireDerogationModeReportedEventArgs(endpoint, null, null));
-                            }
-                        }));
-                    }
+                                var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
+                                    OpenNettyAddress.ToNitooAddress(address).Identifier, unit));
 
-                    if (mode is OpenNettyMode.Broadcast or OpenNettyMode.Multicast && endpoint is { Unit.Scenarios: [_, ..] scenarios })
-                    {
-                        var endpoints = scenarios.ToAsyncEnumerable()
-                            .Where(static scenario => scenario.FunctionCode is 255)
-                            .SelectAwait(scenario => _manager.FindEndpointByNameAsync(scenario.EndpointName))
-                            .Where(static endpoint => endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit: OpenNettyUnit })
-                            .OfType<OpenNettyEndpoint>()
-                            .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating));
+                                if (endpoint is not null && endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
+                                {
+                                    await _events.PublishAsync(new PilotWireDerogationModeReportedEventArgs(endpoint, null, null));
+                                }
+                            }, cancellationToken));
+                        }
 
-                        tasks.Add(Parallel.ForEachAsync(endpoints, async (endpoint, cancellationToken) =>
+                        if (mode is OpenNettyMode.Broadcast or OpenNettyMode.Multicast && endpoint is { Unit.Scenarios: [_, ..] scenarios })
                         {
-                            await _events.PublishAsync(new PilotWireDerogationModeReportedEventArgs(endpoint, null, null), cancellationToken);
-                        }));
-                    }
+                            var endpoints = scenarios.ToAsyncEnumerable()
+                                .Where(static scenario => scenario.FunctionCode is 255)
+                                .SelectAwait(scenario => _manager.FindEndpointByNameAsync(scenario.EndpointName))
+                                .Where(static endpoint => endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit: OpenNettyUnit })
+                                .OfType<OpenNettyEndpoint>()
+                                .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating));
 
-                    await Task.WhenAll(tasks);
+                            tasks.Add(Parallel.ForEachAsync(endpoints, async (endpoint, cancellationToken) =>
+                            {
+                                await _events.PublishAsync(new PilotWireDerogationModeReportedEventArgs(endpoint, null, null), cancellationToken);
+                            }));
+                        }
+
+                        await Task.WhenAll(tasks);
+                    });
                     break;
                 }
 
@@ -1183,32 +1175,31 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Values   : [{ Length: > 0 } value] })
                     when dimension == OpenNettyDimensions.Management.BatteryInformation:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    //
                     // Note: while the battery level is reported using a unit-specific address, it applies to the entire
                     // device: this task retrieves the device endpoint and, if available, report its battery level.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromDecimalZigbeeAddress(
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(OpenNettyAddress.FromDecimalZigbeeAddress(
                         identifier: OpenNettyAddress.ToZigbeeAddress(address).Identifier,
-                        unit      : 0));
-                    
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                        unit      : 0)), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.BatteryLevel))
-                    {
-                        await _events.PublishAsync(new BatteryLevelReportedEventArgs(endpoint, value switch
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
                         {
-                            "0" => 5,
-                            "1" => 33,
-                            "2" => 66,
-                            "3" => 100,
+                            return;
+                        }
 
-                            _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0075))
-                        }));
-                    }
+                        if (endpoint.HasCapability(OpenNettyCapabilities.BatteryLevel))
+                        {
+                            await _events.PublishAsync(new BatteryLevelReportedEventArgs(endpoint, value switch
+                            {
+                                "0" => 5,
+                                "1" => 33,
+                                "2" => 66,
+                                "3" => 100,
+
+                                _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0075))
+                            }), cancellationToken);
+                        }
+                    });
                     break;
                 }
 
@@ -1219,18 +1210,19 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Address : OpenNettyAddress address })
                     when command == OpenNettyCommands.Management.BatteryWeak:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
+                        {
+                            return;
+                        }
 
-                    if (endpoint.HasCapability(OpenNettyCapabilities.BatteryAlert))
-                    {
-                        await _events.PublishAsync(new BatteryAlertReportedEventArgs(endpoint));
-                    }
+                        if (endpoint.HasCapability(OpenNettyCapabilities.BatteryAlert))
+                        {
+                            await _events.PublishAsync(new BatteryAlertReportedEventArgs(endpoint), cancellationToken);
+                        }
+                    });
                     break;
                 }
 
@@ -1245,7 +1237,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                 {
                     // Resolve the endpoint associated with the gateway that received the DIMENSION READ message.
                     var endpoint = await _manager.FindEndpointAsync(endpoint =>
-                        endpoint.Device == arguments.Notification.Gateway.Device && endpoint.Unit is null);
+                        endpoint.Device == notification.Gateway.Device && endpoint.Unit is null);
 
                     if (endpoint is null)
                     {
@@ -1272,31 +1264,32 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                          command == OpenNettyCommands.Scenario.CloseBinding ||
                          command == OpenNettyCommands.Scenario.CancelBinding:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.ZigbeeBinding))
-                    {
-                        if (command == OpenNettyCommands.Scenario.OpenBinding)
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
                         {
-                            await _events.PublishAsync(new BindingOpenEventArgs(endpoint));
+                            return;
                         }
 
-                        else if (command == OpenNettyCommands.Scenario.CloseBinding)
+                        if (endpoint.HasCapability(OpenNettyCapabilities.ZigbeeBinding))
                         {
-                            await _events.PublishAsync(new BindingClosedEventArgs(endpoint));
-                        }
+                            if (command == OpenNettyCommands.Scenario.OpenBinding)
+                            {
+                                await _events.PublishAsync(new BindingOpenEventArgs(endpoint), cancellationToken);
+                            }
 
-                        else if (command == OpenNettyCommands.Scenario.CancelBinding)
-                        {
-                            await _events.PublishAsync(new BindingCanceledEventArgs(endpoint));
+                            else if (command == OpenNettyCommands.Scenario.CloseBinding)
+                            {
+                                await _events.PublishAsync(new BindingClosedEventArgs(endpoint), cancellationToken);
+                            }
+
+                            else if (command == OpenNettyCommands.Scenario.CancelBinding)
+                            {
+                                await _events.PublishAsync(new BindingCanceledEventArgs(endpoint), cancellationToken);
+                            }
                         }
-                    }
+                    });
                     break;
                 }
 
@@ -1308,16 +1301,17 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Values   : [{ Length: > 0 }, { Length: > 0 }, { Length: > 0 }, { Length: > 0 }] values })
                     when dimension == OpenNettyDimensions.Diagnostics.DeviceDescription:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
+                        {
+                            return;
+                        }
 
-                    await _events.PublishAsync(new DeviceDescriptionReportedEventArgs(endpoint,
-                        OpenNettyModels.Diagnostics.DeviceDescription.CreateFromDeviceDescription(values)));
+                        await _events.PublishAsync(new DeviceDescriptionReportedEventArgs(endpoint,
+                            OpenNettyModels.Diagnostics.DeviceDescription.CreateFromDeviceDescription(values)), cancellationToken);
+                    });
                     break;
                 }
 
@@ -1330,28 +1324,29 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Values   : [{ Length: > 0 } value, ..] })
                     when dimension == OpenNettyDimensions.Lighting.DimmerStep:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
-
-                    if (endpoint.HasCapability(OpenNettyCapabilities.DimmingScenarioState))
-                    {
-                        var step = int.Parse(value, CultureInfo.InvariantCulture);
-                        if (step is >= 128)
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
                         {
-                            step -= 256;
+                            return;
                         }
 
-                        await _events.PublishAsync(new DimmingStepReportedEventArgs(endpoint, step));
-                    }
+                        if (endpoint.HasCapability(OpenNettyCapabilities.DimmingScenarioState))
+                        {
+                            var step = int.Parse(value, CultureInfo.InvariantCulture);
+                            if (step is >= 128)
+                            {
+                                step -= 256;
+                            }
+
+                            await _events.PublishAsync(new DimmingStepReportedEventArgs(endpoint, step), cancellationToken);
+                        }
+                    });
                     break;
                 }
 
-                case (OpenNettyNotification notification,
+                case (OpenNettyNotifications.MessageReceived or OpenNettyNotifications.MessageSent,
                       OpenNettyMessage { Protocol: OpenNettyProtocol.Nitoo,
                                          Type    : OpenNettyMessageType.BusCommand,
                                          Command : OpenNettyCommand command,
@@ -1359,179 +1354,178 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                          Mode    : OpenNettyMode mode })
                     // Note: timed and progressive scenarios are parameterized.
                     when command == OpenNettyCommands.Scenario.Action ||
-                        (command.Category   == OpenNettyCategories.Scenarios                  &&
-                         command.Value      == OpenNettyCommands.Scenario.ActionForTime.Value &&
-                         command.Parameters is [{ Length: > 0 }]) ||
-                        (command.Category   == OpenNettyCategories.Scenarios                 &&
-                         command.Value      == OpenNettyCommands.Scenario.ActionInTime.Value &&
-                         command.Parameters is [{ Length: > 0 }]):
+                         command.WithParameters([]) == OpenNettyCommands.Scenario.ActionForTime ||
+                         command.WithParameters([]) == OpenNettyCommands.Scenario.ActionInTime:
                 {
-                    // Ignore the message if the corresponding endpoint couldn't be resolved or if it
-                    // was received by a different gateway than the one associated with the endpoint.
-                    var endpoint = await _manager.FindEndpointByAddressAsync(address);
-                    if (endpoint is null || (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway))
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
                     {
-                        return;
-                    }
-
-                    List<Task> tasks = [];
-
-                    if (command == OpenNettyCommands.Scenario.Action)
-                    {
-                        if (!endpoint.HasCapability(OpenNettyCapabilities.ActionScenarioState))
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
                         {
-                            break;
+                            return;
                         }
 
-                        if (mode is OpenNettyMode.Broadcast && notification is OpenNettyNotifications.MessageReceived)
-                        {
-                            tasks.Add(_events.PublishAsync(new BasicScenarioReportedEventArgs(endpoint)).AsTask());
-                        }
+                        List<Task> tasks = [];
 
-                        // Note: since they are radiofrequency devices, the current state of Nitoo wireless burglar alarms
-                        // cannot be retrieved using a unit description request. To inform devices associated using a
-                        // PnL scenario of a state change, Nitoo alarms broadcast it using unit-specific ACTION scenarios.
-                        tasks.Add(Task.Run(async () =>
+                        if (command == OpenNettyCommands.Scenario.Action)
                         {
-                            var (identifier, unit) = OpenNettyAddress.ToNitooAddress(address);
-                            if (unit is not (>= 4 and <= 9))
+                            if (!endpoint.HasCapability(OpenNettyCapabilities.ActionScenarioState))
                             {
                                 return;
                             }
 
-                            var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(identifier, 0));
-                            if (endpoint is null || !endpoint.HasCapability(OpenNettyCapabilities.WirelessBurglarAlarmState))
+                            if (mode is OpenNettyMode.Broadcast && notification is OpenNettyNotifications.MessageReceived)
+                            {
+                                tasks.Add(_events.PublishAsync(new BasicScenarioReportedEventArgs(endpoint), cancellationToken).AsTask());
+                            }
+
+                            // Note: since they are radiofrequency devices, the current state of Nitoo wireless burglar alarms
+                            // cannot be retrieved using a unit description request. To inform devices associated using a
+                            // PnL scenario of a state change, Nitoo alarms broadcast it using unit-specific ACTION scenarios.
+                            tasks.Add(Task.Run(async () =>
+                            {
+                                var (identifier, unit) = OpenNettyAddress.ToNitooAddress(address);
+                                if (unit is not (>= 4 and <= 9))
+                                {
+                                    return;
+                                }
+
+                                var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(identifier, 0));
+                                if (endpoint is null || !endpoint.HasCapability(OpenNettyCapabilities.WirelessBurglarAlarmState))
+                                {
+                                    return;
+                                }
+
+                                await _events.PublishAsync(new WirelessBurglarAlarmStateReportedEventArgs(endpoint, unit switch
+                                {
+                                    4 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.Armed,
+                                    5 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.Disarmed,
+                                    6 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.PartiallyArmed,
+                                    7 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.Triggered,
+                                    8 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.ExitDelayElapsed,
+                                    9 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.EventDetected,
+
+                                    _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0075))
+                                }));
+                            }, cancellationToken));
+                        }
+
+                        else if (command.Value == OpenNettyCommands.Scenario.ActionForTime.Value)
+                        {
+                            if (!endpoint.HasCapability(OpenNettyCapabilities.TimedScenarioState))
                             {
                                 return;
                             }
 
-                            await _events.PublishAsync(new WirelessBurglarAlarmStateReportedEventArgs(endpoint, unit switch
+                            if (notification is OpenNettyNotifications.MessageReceived && mode is OpenNettyMode.Broadcast)
                             {
-                                4 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.Armed,
-                                5 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.Disarmed,
-                                6 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.PartiallyArmed,
-                                7 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.Triggered,
-                                8 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.ExitDelayElapsed,
-                                9 => OpenNettyModels.Alarm.WirelessBurglarAlarmState.EventDetected,
+                                var duration = Math.Round(double.Parse(command.Parameters[0], CultureInfo.InvariantCulture) / 5, MidpointRounding.AwayFromZero);
 
-                                _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0075))
-                            }));
-                        }));
-                    }
-
-                    else if (command.Value == OpenNettyCommands.Scenario.ActionForTime.Value)
-                    {
-                        if (!endpoint.HasCapability(OpenNettyCapabilities.TimedScenarioState))
-                        {
-                            break;
+                                await _events.PublishAsync(new TimedScenarioReportedEventArgs(endpoint, TimeSpan.FromSeconds(duration)), cancellationToken);
+                            }
                         }
 
-                        if (notification is OpenNettyNotifications.MessageReceived && mode is OpenNettyMode.Broadcast)
+                        else if (command.Value == OpenNettyCommands.Scenario.ActionInTime.Value)
                         {
-                            var duration = Math.Round(double.Parse(command.Parameters[0], CultureInfo.InvariantCulture) / 5, MidpointRounding.AwayFromZero);
-
-                            await _events.PublishAsync(new TimedScenarioReportedEventArgs(endpoint, TimeSpan.FromSeconds(duration)));
-                        }
-                    }
-
-                    else if (command.Value == OpenNettyCommands.Scenario.ActionInTime.Value)
-                    {
-                        if (!endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenarioState))
-                        {
-                            break;
-                        }
-
-                        if (notification is OpenNettyNotifications.MessageReceived && mode is OpenNettyMode.Broadcast)
-                        {
-                            var duration = Math.Round(double.Parse(command.Parameters[0], CultureInfo.InvariantCulture) / 5, MidpointRounding.AwayFromZero);
-
-                            await _events.PublishAsync(new ProgressiveScenarioReportedEventArgs(endpoint, TimeSpan.FromSeconds(duration)));
-                        }
-                    }
-
-                    // Note: on endpoints that don't support dimming, a "SCENARIO ACTION", "SCENARIO ACTION IN TIME" or
-                    // "SCENARIO ACTION FOR TIME" BUS COMMAND always results in the associated unit being switched on.
-                    //
-                    // For endpoints that support dimming, the actual brightness level is retrieved asynchronously
-                    // by a dedicated event handler to ensure the exact brightness level is correctly reported.
-                    if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState) &&
-                       !endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) &&
-                       !endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState))
-                    {
-                        tasks.Add(ReportOnStateAsync(endpoint, CancellationToken.None).AsTask());
-                    }
-
-                    if (endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit.Definition.AssociatedUnitId: byte unit })
-                    {
-                        tasks.Add(Task.Run(async () =>
-                        {
-                            var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
-                                OpenNettyAddress.ToNitooAddress(address).Identifier, unit));
-
-                            if (endpoint is null || !endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
+                            if (!endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenarioState))
                             {
                                 return;
                             }
 
-                            // Note: on endpoints that don't support dimming, a "SCENARIO ACTION", "SCENARIO ACTION IN TIME" or
-                            // "SCENARIO ACTION FOR TIME" BUS COMMAND always results in the associated unit being switched on.
-                            //
-                            // For endpoints that support dimming, the actual brightness level is retrieved asynchronously
-                            // by a dedicated event handler to ensure the exact brightness level is correctly reported.
-                            if (!endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) &&
-                                !endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState))
+                            if (notification is OpenNettyNotifications.MessageReceived && mode is OpenNettyMode.Broadcast)
                             {
-                                await ReportOnStateAsync(endpoint, CancellationToken.None);
-                            }
-                        }));
-                    }
+                                var duration = Math.Round(double.Parse(command.Parameters[0], CultureInfo.InvariantCulture) / 5, MidpointRounding.AwayFromZero);
 
-                    if (endpoint is { Unit.Scenarios: [_, ..] scenarios })
-                    {
-                        tasks.Add(Parallel.ForEachAsync(scenarios, async (scenario, cancellationToken) =>
+                                await _events.PublishAsync(new ProgressiveScenarioReportedEventArgs(endpoint, TimeSpan.FromSeconds(duration)), cancellationToken);
+                            }
+                        }
+
+                        // Note: on endpoints that don't support dimming, a "SCENARIO ACTION", "SCENARIO ACTION IN TIME" or
+                        // "SCENARIO ACTION FOR TIME" BUS COMMAND always results in the associated unit being switched on.
+                        //
+                        // For endpoints that support dimming, the actual brightness level is retrieved asynchronously
+                        // by a dedicated event handler to ensure the exact brightness level is correctly reported.
+                        if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState) &&
+                           !endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) &&
+                           !endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState))
                         {
-                            var endpoint = await _manager.FindEndpointByNameAsync(scenario.EndpointName, cancellationToken);
-                            if (endpoint is null ||
-                                endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is not (null or OpenNettySettings.ActuatorTypes.Lighting))
-                            {
-                                return;
-                            }
+                            tasks.Add(ReportOnStateAsync(endpoint, cancellationToken).AsTask());
+                        }
 
-                            if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
+                        if (endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit.Definition.AssociatedUnitId: byte unit })
+                        {
+                            tasks.Add(Task.Run(async () =>
                             {
-                                if (scenario.FunctionCode is 101 or 103 or (>= 0 and <= 100))
+                                var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
+                                    OpenNettyAddress.ToNitooAddress(address).Identifier, unit));
+
+                                if (endpoint is null || !endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
+                                {
+                                    return;
+                                }
+
+                                // Note: on endpoints that don't support dimming, a "SCENARIO ACTION", "SCENARIO ACTION IN TIME" or
+                                // "SCENARIO ACTION FOR TIME" BUS COMMAND always results in the associated unit being switched on.
+                                //
+                                // For endpoints that support dimming, the actual brightness level is retrieved asynchronously
+                                // by a dedicated event handler to ensure the exact brightness level is correctly reported.
+                                if (!endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) &&
+                                    !endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState))
                                 {
                                     await ReportOnStateAsync(endpoint, cancellationToken);
                                 }
+                            }, cancellationToken));
+                        }
 
-                                else if (scenario.FunctionCode is 102 or 104)
-                                {
-                                    await _events.PublishAsync(new SwitchStateReportedEventArgs(endpoint,
-                                        OpenNettyModels.Lighting.SwitchState.Off), cancellationToken);
-                                }
-                            }
-
-                            if (endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) ||
-                                endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState))
+                        if (endpoint is { Unit.Scenarios: [_, ..] scenarios })
+                        {
+                            tasks.Add(Parallel.ForEachAsync(scenarios, async (scenario, cancellationToken) =>
                             {
-                                // Note: for Nitoo devices supporting dimming, an ON scenario always changes the brightness to 100%.
-                                if (scenario.FunctionCode is 101 or 103)
+                                var endpoint = await _manager.FindEndpointByNameAsync(scenario.EndpointName, cancellationToken);
+                                if (endpoint is null)
                                 {
-                                    await _events.PublishAsync(new BrightnessReportedEventArgs(endpoint, 100), cancellationToken);
+                                    return;
                                 }
 
-                                // Note: the special brightness level "0" always indicates that the output is switched off.
-                                // While Nitoo devices normally don't restore the last known brightness level, the brightness
-                                // level is only reported if it's higher than zero for consistency with MyHome/SCS devices.
-                                else if (scenario.FunctionCode is >= 1 and <= 100)
+                                if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
                                 {
-                                    await _events.PublishAsync(new BrightnessReportedEventArgs(endpoint, scenario.FunctionCode), cancellationToken);
-                                }
-                            }
-                        }));
-                    }
+                                    if (scenario.FunctionCode is 101 or 103 or (>= 0 and <= 100))
+                                    {
+                                        await ReportOnStateAsync(endpoint, cancellationToken);
+                                    }
 
-                    await Task.WhenAll(tasks);
+                                    else if (scenario.FunctionCode is 102 or 104)
+                                    {
+                                        await _events.PublishAsync(new SwitchStateReportedEventArgs(endpoint,
+                                            OpenNettyModels.Lighting.SwitchState.Off), cancellationToken);
+                                    }
+                                }
+
+                                if (endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) ||
+                                    endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState))
+                                {
+                                    // Note: for Nitoo devices supporting dimming, an ON scenario always changes the brightness to 100%.
+                                    if (scenario.FunctionCode is 101 or 103)
+                                    {
+                                        await _events.PublishAsync(new BrightnessReportedEventArgs(endpoint, 100), cancellationToken);
+                                    }
+
+                                    // Note: the special brightness level "0" always indicates that the output is switched off.
+                                    // To avoid overriding the last known level (which is typically restored by SCS devices when
+                                    // receiving an ON command), the brightness level is only reported if it's higher than zero.
+                                    // 
+                                    // Note: while Nitoo devices normally don't restore the last known brightness level when
+                                    // receiving an ON command, the same rule applies for consistency with MyHome/SCS devices.
+                                    else if (scenario.FunctionCode is >= 1 and <= 100)
+                                    {
+                                        await _events.PublishAsync(new BrightnessReportedEventArgs(endpoint, scenario.FunctionCode), cancellationToken);
+                                    }
+                                }
+                            }));
+                        }
+
+                        await Task.WhenAll(tasks);
+                    });
 
                     async ValueTask ReportOnStateAsync(OpenNettyEndpoint endpoint, CancellationToken cancellationToken)
                     {
@@ -1550,7 +1544,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                 }
             }
         })
-        .Do((Exception exception) => _logger.LogWarning(6018, exception, SR.GetResourceString(SR.ID6018)))
+        .Do(exception => _logger.LogWarning(6018, exception, SR.GetResourceString(SR.ID6018)))
         .Retry()
         .SubscribeAsync(static message => ValueTask.CompletedTask),
 
@@ -1608,9 +1602,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     Address : not null,
                     Mode    : OpenNettyMode.Broadcast } message }
                 // Note: timed scenarios are reported using parameterized BUS COMMAND frames.
-                when command.Category   == OpenNettyCategories.Scenarios                  &&
-                     command.Value      == OpenNettyCommands.Scenario.ActionForTime.Value &&
-                     command.Parameters is [{ Length: > 0 }]
+                when command.WithParameters([]) == OpenNettyCommands.Scenario.ActionForTime
                     => AsyncObservable.Return<(OpenNettyNotification Notification, OpenNettyMessage Message)>((notification, message)),
 
             OpenNettyNotifications.MessageReceived {
@@ -1622,9 +1614,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     Address : not null,
                     Mode    : OpenNettyMode.Broadcast } message }
                 // Note: progressive scenarios are reported using parameterized BUS COMMAND frames.
-                when command.Category   == OpenNettyCategories.Scenarios                 &&
-                     command.Value      == OpenNettyCommands.Scenario.ActionInTime.Value &&
-                     command.Parameters is [{ Length: > 0 }]
+                when command.WithParameters([]) == OpenNettyCommands.Scenario.ActionInTime
                     => AsyncObservable.Return<(OpenNettyNotification Notification, OpenNettyMessage Message)>((notification, message)),
 
             // Nitoo devices allow changing the brightness level of a local unit (and of associated
@@ -1650,15 +1640,17 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
         .SelectMany(static group => group.Throttle(TimeSpan.FromSeconds(group.Key.Type is OpenNettyAddressType.Nitoo ? 0.5 : 1)))
         .Do(async arguments =>
         {
-            await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(arguments.Message.Address!.Value), async (endpoint, cancellationToken) =>
+            var (notification, message) = arguments;
+
+            await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address!.Value), async (endpoint, cancellationToken) =>
             {
                 // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
-                if (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway)
+                if (endpoint.Gateway != notification.Gateway)
                 {
                     return;
                 }
 
-                switch (arguments.Message)
+                switch (message)
                 {
                     case { Type: OpenNettyMessageType.BusCommand, Command: OpenNettyCommand command }
                         when command == OpenNettyCommands.Scenario.Action && !endpoint.HasCapability(OpenNettyCapabilities.ActionScenarioState):
@@ -1685,14 +1677,12 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                         break;
 
                     case { Type: OpenNettyMessageType.BusCommand, Command: OpenNettyCommand command }
-                        when command.Category == OpenNettyCategories.Scenarios                  &&
-                             command.Value    == OpenNettyCommands.Scenario.ActionForTime.Value &&
+                        when command.WithParameters([]) == OpenNettyCommands.Scenario.ActionForTime &&
                             !endpoint.HasCapability(OpenNettyCapabilities.TimedScenarioState):
                         return;
 
                     case { Type: OpenNettyMessageType.BusCommand, Command: OpenNettyCommand command }
-                        when command.Category == OpenNettyCategories.Scenarios                 &&
-                             command.Value    == OpenNettyCommands.Scenario.ActionInTime.Value &&
+                        when command.WithParameters([]) == OpenNettyCommands.Scenario.ActionInTime &&
                             !endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenarioState):
                         return;
 
@@ -1715,7 +1705,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     tasks.Add(Task.Run(async () =>
                     {
                         var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
-                            OpenNettyAddress.ToNitooAddress(arguments.Message.Address!.Value).Identifier, unit));
+                            OpenNettyAddress.ToNitooAddress(message.Address!.Value).Identifier, unit));
 
                         if (endpoint is null)
                         {
@@ -1734,9 +1724,9 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     }, cancellationToken));
                 }
 
-                if (arguments.Message.Protocol  is OpenNettyProtocol.Nitoo                 &&
-                    arguments.Message.Type      is OpenNettyMessageType.DimensionSet       &&
-                    arguments.Message.Dimension == OpenNettyDimensions.Lighting.DimmerStep &&
+                if (message.Protocol  is OpenNettyProtocol.Nitoo                 &&
+                    message.Type      is OpenNettyMessageType.DimensionSet       &&
+                    message.Dimension == OpenNettyDimensions.Lighting.DimmerStep &&
                     endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit.Scenarios: [_, ..] scenarios })
                 {
                     var endpoints = scenarios.ToAsyncEnumerable()
@@ -1755,7 +1745,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                 await Task.WhenAll(tasks);
             });
         })
-        .Do((Exception exception) => _logger.LogWarning(6018, exception, SR.GetResourceString(SR.ID6018)))
+        .Do(exception => _logger.LogWarning(6018, exception, SR.GetResourceString(SR.ID6018)))
         .Retry()
         .SubscribeAsync(static notification => ValueTask.CompletedTask),
 
@@ -1772,78 +1762,70 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     Address : not null,
                     Mode    : OpenNettyMode.Broadcast } message }
                 // Note: timed scenarios are reported using parameterized BUS COMMAND frames.
-                when command.Category   == OpenNettyCategories.Scenarios                  &&
-                     command.Value      == OpenNettyCommands.Scenario.ActionForTime.Value &&
-                     command.Parameters is [{ Length: > 0 } value]                        &&
-                     Math.Round(double.Parse(value, CultureInfo.InvariantCulture) / 5, MidpointRounding.AwayFromZero) is double duration
+                when command.WithParameters([]) == OpenNettyCommands.Scenario.ActionForTime &&
+                     Math.Round(double.Parse(command.Parameters[0], CultureInfo.InvariantCulture) / 5, MidpointRounding.AwayFromZero) is double duration
                      => AsyncObservable.Timer(TimeSpan.FromSeconds(duration)).Select(_ => (Notification: notification, Message: message)),
 
             _ => AsyncObservable.Empty<(OpenNettyNotification Notification, OpenNettyMessage Message)>()
         })
         .Do(async arguments =>
         {
-            // Ignore the message if no endpoint matching the associated address could be resolved.
-            var endpoint = await _manager.FindEndpointByAddressAsync(arguments.Message.Address!.Value);
-            if (endpoint is null)
-            {
-                return;
-            }
+            var (notification, message) = arguments;
 
-            // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
-            if (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway)
+            await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address!.Value), async (endpoint, cancellationToken) =>
             {
-                return;
-            }
-
-            if (!endpoint.HasCapability(OpenNettyCapabilities.TimedScenarioState))
-            {
-                return;
-            }
-
-            List<Task> tasks = [];
-
-            if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState) &&
-                endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is null or OpenNettySettings.ActuatorTypes.Lighting)
-            {
-                tasks.Add(ReportOffStateAsync(endpoint, CancellationToken.None).AsTask());
-            }
-
-            if (endpoint is { Unit.Definition.AssociatedUnitId: byte unit })
-            {
-                tasks.Add(Task.Run(async () =>
+                // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                if (endpoint.Gateway != notification.Gateway)
                 {
-                    var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
-                        OpenNettyAddress.ToNitooAddress(arguments.Message.Address!.Value).Identifier, unit));
+                    return;
+                }
 
-                    if (endpoint is not null &&
-                        endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState) &&
-                        endpoint.GetStringSetting(OpenNettySettings.ActuatorType) is null or OpenNettySettings.ActuatorTypes.Lighting)
+                if (!endpoint.HasCapability(OpenNettyCapabilities.TimedScenarioState))
+                {
+                    return;
+                }
+
+                List<Task> tasks = [];
+
+                if (endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
+                {
+                    tasks.Add(ReportOffStateAsync(endpoint, cancellationToken).AsTask());
+                }
+
+                if (endpoint is { Unit.Definition.AssociatedUnitId: byte unit })
+                {
+                    tasks.Add(Task.Run(async () =>
                     {
-                        await ReportOffStateAsync(endpoint, CancellationToken.None);
-                    }
-                }));
-            }
+                        var endpoint = await _manager.FindEndpointByAddressAsync(OpenNettyAddress.FromNitooAddress(
+                            OpenNettyAddress.ToNitooAddress(message.Address!.Value).Identifier, unit));
 
-            if (endpoint is { Unit.Scenarios: [_, ..] scenarios })
-            {
-                var endpoints = scenarios.ToAsyncEnumerable()
-                    .Where(static scenario => scenario.FunctionCode is < 105)
-                    .SelectAwait(scenario => _manager.FindEndpointByNameAsync(scenario.EndpointName))
-                    .Where(static endpoint => endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit: OpenNettyUnit })
-                    .OfType<OpenNettyEndpoint>()
-                    .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
-                    .Where(static endpoint => endpoint.GetStringSetting(OpenNettySettings.ActuatorType)
-                        is null or OpenNettySettings.ActuatorTypes.Lighting);
+                        if (endpoint is not null &&
+                            endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState))
+                        {
+                            await ReportOffStateAsync(endpoint, cancellationToken);
+                        }
+                    }, cancellationToken));
+                }
 
-                tasks.Add(Parallel.ForEachAsync(endpoints, ReportOffStateAsync));
-            }
+                if (endpoint is { Unit.Scenarios: [_, ..] scenarios })
+                {
+                    var endpoints = scenarios.ToAsyncEnumerable()
+                        .Where(static scenario => scenario.FunctionCode is < 105)
+                        .SelectAwait(scenario => _manager.FindEndpointByNameAsync(scenario.EndpointName))
+                        .Where(static endpoint => endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit: OpenNettyUnit })
+                        .OfType<OpenNettyEndpoint>()
+                        .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchState));
 
-            await Task.WhenAll(tasks);
+                    tasks.Add(Parallel.ForEachAsync(endpoints, ReportOffStateAsync));
+                }
+
+                await Task.WhenAll(tasks);
+            });
 
             ValueTask ReportOffStateAsync(OpenNettyEndpoint endpoint, CancellationToken cancellationToken)
                 => _events.PublishAsync(new SwitchStateReportedEventArgs(endpoint, OpenNettyModels.Lighting.SwitchState.Off), cancellationToken);
         })
-        .Do((Exception exception) => _logger.LogWarning(6018, exception, SR.GetResourceString(SR.ID6018)))
+        .Do(exception => _logger.LogWarning(6018, exception, SR.GetResourceString(SR.ID6018)))
         .Retry()
         .SubscribeAsync(static notification => ValueTask.CompletedTask),
 
@@ -1860,9 +1842,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     Address : not null,
                     Mode    : OpenNettyMode.Broadcast } message }
                 // Note: pilot wire mode changes are reported using parameterized BUS COMMAND frames.
-                when command.Category   == OpenNettyCategories.TemperatureControl                           &&
-                     command.Value      == OpenNettyCommands.TemperatureControl.WirePilotSetpointMode.Value &&
-                     command.Parameters is [{ Length: > 0 }]
+                when command.WithParameters([]) == OpenNettyCommands.TemperatureControl.WirePilotSetpointMode
                     => AsyncObservable.Return<(OpenNettyNotification Notification, OpenNettyMessage Message)>((notification, message)),
 
             OpenNettyNotifications.MessageReceived {
@@ -1884,9 +1864,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     Command : OpenNettyCommand command,
                     Address : not null } message }
                 // Note: pilot wire mode changes are emitted using parameterized BUS COMMAND frames.
-                when command.Category   == OpenNettyCategories.TemperatureControl                           &&
-                     command.Value      == OpenNettyCommands.TemperatureControl.WirePilotSetpointMode.Value &&
-                     command.Parameters is [{ Length: > 0 }]
+                when command.WithParameters([]) == OpenNettyCommands.TemperatureControl.WirePilotSetpointMode
                      => AsyncObservable.Return<(OpenNettyNotification Notification, OpenNettyMessage Message)>((notification, message)),
 
             OpenNettyNotifications.MessageSent {
@@ -1905,25 +1883,23 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
         .SelectMany(static group => group.Throttle(TimeSpan.FromSeconds(0.5)))
         .Do(async arguments =>
         {
-            // Ignore the message if no endpoint matching the associated address could be resolved.
-            var endpoint = await _manager.FindEndpointByAddressAsync(arguments.Message.Address!.Value);
-            if (endpoint is null)
-            {
-                return;
-            }
+            var (notification, message) = arguments;
 
-            // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
-            if (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway)
+            await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address!.Value), async (endpoint, cancellationToken) =>
             {
-                return;
-            }
+                // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                if (endpoint.Gateway != notification.Gateway)
+                {
+                    return;
+                }
 
-            if (endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
-            {
-                _ = await _controller.GetPilotWireConfigurationAsync(endpoint);
-            }
+                if (endpoint.HasCapability(OpenNettyCapabilities.PilotWireHeating))
+                {
+                    _ = await _controller.GetPilotWireConfigurationAsync(endpoint, cancellationToken);
+                }
+            });
         })
-        .Do((Exception exception) => _logger.LogWarning(6018, exception, SR.GetResourceString(SR.ID6018)))
+        .Do(exception => _logger.LogWarning(6018, exception, SR.GetResourceString(SR.ID6018)))
         .Retry()
         .SubscribeAsync(static notification => ValueTask.CompletedTask),
 
@@ -1949,55 +1925,53 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
         .SelectMany(static group => group.Throttle(TimeSpan.FromSeconds(2.5)))
         .Do(async arguments =>
         {
-            // Ignore the message if no endpoint matching the associated address could be resolved.
-            var endpoint = await _manager.FindEndpointByAddressAsync(arguments.Message.Address!.Value);
-            if (endpoint is null)
-            {
-                return;
-            }
+            var (notification, message) = arguments;
 
-            // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
-            if (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway)
+            await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address!.Value), async (endpoint, cancellationToken) =>
             {
-                return;
-            }
-
-            if (!endpoint.HasCapability(OpenNettyCapabilities.SmartMeterInformation))
-            {
-                return;
-            }
-
-            var endpoints = _manager.EnumerateEndpointsAsync()
-                .Where(static endpoint => endpoint.Protocol is OpenNettyProtocol.Nitoo)
-                .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.WaterHeating))
-                .Where(endpoint => endpoint.Address is OpenNettyAddress address &&
-                    OpenNettyAddress.ToNitooAddress(address) is { Identifier: uint identifier } &&
-                    identifier == OpenNettyAddress.ToNitooAddress(arguments.Message.Address!.Value).Identifier);
-
-            await Parallel.ForEachAsync(endpoints, async (endpoint, cancellationToken) =>
-            {
-                switch (arguments.Message.Values, await _controller.GetUnitDescriptionAsync(endpoint, cancellationToken))
+                // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                if (endpoint.Gateway != notification.Gateway)
                 {
-                    // If the unit description indicates water is not heating when an "off-peak" signal
-                    // is received, this means that production of hot water was turned off by the user.
-                    case (["2"], { FunctionCode: 133, Values: ["0" or "32"] }):
-                        await _events.PublishAsync(new WaterHeaterSetpointModeReportedEventArgs(endpoint,
-                            OpenNettyModels.TemperatureControl.WaterHeaterMode.ForcedOff), cancellationToken);
-                        break;
-
-                    case (["2"], { FunctionCode: 133, Values: ["1" or "33"] }):
-                        await _events.PublishAsync(new WaterHeaterSetpointModeReportedEventArgs(endpoint,
-                            OpenNettyModels.TemperatureControl.WaterHeaterMode.Automatic), cancellationToken);
-                        break;
-
-                    case (["2"], { FunctionCode: 133, Values: ["17"] }):
-                        await _events.PublishAsync(new WaterHeaterSetpointModeReportedEventArgs(endpoint,
-                            OpenNettyModels.TemperatureControl.WaterHeaterMode.ForcedOn), cancellationToken);
-                        break;
+                    return;
                 }
+
+                if (!endpoint.HasCapability(OpenNettyCapabilities.SmartMeterInformation))
+                {
+                    return;
+                }
+
+                var endpoints = _manager.EnumerateEndpointsAsync(cancellationToken)
+                    .Where(static endpoint => endpoint.Protocol is OpenNettyProtocol.Nitoo)
+                    .Where(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.WaterHeating))
+                    .Where(endpoint => endpoint.Address is OpenNettyAddress address &&
+                        OpenNettyAddress.ToNitooAddress(address) is { Identifier: uint identifier } &&
+                        identifier == OpenNettyAddress.ToNitooAddress(message.Address!.Value).Identifier);
+
+                await Parallel.ForEachAsync(endpoints, async (endpoint, cancellationToken) =>
+                {
+                    switch (message.Values, await _controller.GetUnitDescriptionAsync(endpoint, cancellationToken))
+                    {
+                        // If the unit description indicates water is not heating when an "off-peak" signal
+                        // is received, this means that production of hot water was turned off by the user.
+                        case (["2"], { FunctionCode: 133, Values: ["0" or "32"] }):
+                            await _events.PublishAsync(new WaterHeaterSetpointModeReportedEventArgs(endpoint,
+                                OpenNettyModels.TemperatureControl.WaterHeaterMode.ForcedOff), cancellationToken);
+                            break;
+
+                        case (["2"], { FunctionCode: 133, Values: ["1" or "33"] }):
+                            await _events.PublishAsync(new WaterHeaterSetpointModeReportedEventArgs(endpoint,
+                                OpenNettyModels.TemperatureControl.WaterHeaterMode.Automatic), cancellationToken);
+                            break;
+
+                        case (["2"], { FunctionCode: 133, Values: ["17"] }):
+                            await _events.PublishAsync(new WaterHeaterSetpointModeReportedEventArgs(endpoint,
+                                OpenNettyModels.TemperatureControl.WaterHeaterMode.ForcedOn), cancellationToken);
+                            break;
+                    }
+                });
             });
         })
-        .Do((Exception exception) => _logger.LogWarning(6018, exception, SR.GetResourceString(SR.ID6018)))
+        .Do(exception => _logger.LogWarning(6018, exception, SR.GetResourceString(SR.ID6018)))
         .Retry()
         .SubscribeAsync(static notification => ValueTask.CompletedTask),
 
@@ -2022,25 +1996,23 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
         .SelectMany(static group => group.Throttle(TimeSpan.FromSeconds(0.5)))
         .Do(async arguments =>
         {
-            // Ignore the message if no endpoint matching the associated address could be resolved.
-            var endpoint = await _manager.FindEndpointByAddressAsync(arguments.Message.Address!.Value);
-            if (endpoint is null)
-            {
-                return;
-            }
+            var (notification, message) = arguments;
 
-            // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
-            if (endpoint.Gateway is not null && arguments.Notification.Gateway != endpoint.Gateway)
+            await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address!.Value), async (endpoint, cancellationToken) =>
             {
-                return;
-            }
+                // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                if (endpoint.Gateway != notification.Gateway)
+                {
+                    return;
+                }
 
-            if (endpoint.HasCapability(OpenNettyCapabilities.WaterHeating))
-            {
-                _ = await _controller.GetWaterHeaterStateAsync(endpoint);
-            }
+                if (endpoint.HasCapability(OpenNettyCapabilities.WaterHeating))
+                {
+                    _ = await _controller.GetWaterHeaterStateAsync(endpoint, cancellationToken);
+                }
+            });
         })
-        .Do((Exception exception) => _logger.LogWarning(6018, exception, SR.GetResourceString(SR.ID6018)))
+        .Do(exception => _logger.LogWarning(6018, exception, SR.GetResourceString(SR.ID6018)))
         .Retry()
         .SubscribeAsync(static notification => ValueTask.CompletedTask)
     ]);

--- a/src/OpenNetty/OpenNettyDevices.xml
+++ b/src/OpenNetty/OpenNettyDevices.xml
@@ -959,6 +959,7 @@
     <Capability Name="Hardware version" />
     <Capability Name="OpenWebNet gateway" />
     <Capability Name="OpenWebNet generic session" />
+    <Capability Name="Zigbee network management" />
     <Capability Name="Zigbee supervision" />
 
     <Setting Name="Serial port baud rate" Value="19200" />

--- a/src/OpenNetty/OpenNettyEndpoint.cs
+++ b/src/OpenNetty/OpenNettyEndpoint.cs
@@ -44,7 +44,7 @@ public sealed class OpenNettyEndpoint : IEquatable<OpenNettyEndpoint>
     /// Note: incoming frames that point to this endpoint but are not
     /// received by the specified gateway will be automatically ignored.
     /// </remarks>
-    public OpenNettyGateway? Gateway { get; init; }
+    public required OpenNettyGateway Gateway { get; init; }
 
     /// <summary>
     /// Gets or sets the medium associated with the endpoint.

--- a/src/OpenNetty/OpenNettyGatewayOptions.cs
+++ b/src/OpenNetty/OpenNettyGatewayOptions.cs
@@ -4,10 +4,6 @@
  * the license and the contributors participating to this project.
  */
 
-using Microsoft.Extensions.Logging;
-using Polly;
-using Polly.Retry;
-
 namespace OpenNetty;
 
 /// <summary>
@@ -16,74 +12,19 @@ namespace OpenNetty;
 public sealed record class OpenNettyGatewayOptions
 {
     /// <summary>
-    /// Gets or sets the action validation timeout (Nitoo only).
+    /// Gets or sets the default session options to use when instantiating sessions.
     /// </summary>
-    public required TimeSpan ActionValidationTimeout { get; init; }
+    public required OpenNettySessionOptions DefaultSessionOptions { get; init; }
 
     /// <summary>
-    /// Gets or sets the maximum lifetime of command sessions.
+    /// Gets or sets the default transmission options to use when sending messages.
     /// </summary>
-    public required TimeSpan CommandSessionMaximumLifetime { get; init; }
+    public required OpenNettyTransmissionOptions DefaultTransmissionOptions { get; init; }
 
     /// <summary>
-    /// Gets or sets the connection negotiation timeout.
+    /// Gets or sets the default worker options to use when managing workers.
     /// </summary>
-    public required TimeSpan ConnectionNegotiationTimeout { get; init; }
-
-    /// <summary>
-    /// Gets or sets a boolean indicating whether the supervision mode should be enabled (Zigbee only).
-    /// </summary>
-    public required bool EnableSupervisionMode { get; init; }
-
-    /// <summary>
-    /// Gets or sets the frame acknowledgement timeout.
-    /// </summary>
-    public required TimeSpan FrameAcknowledgementTimeout { get; init; }
-
-    /// <summary>
-    /// Gets or sets the maximum number of concurrent command sessions allowed.
-    /// </summary>
-    public required byte MaximumConcurrentCommandSessions { get; init; }
-
-    /// <summary>
-    /// Gets or sets the reply timeout used when multiple dimensions should be returned.
-    /// </summary>
-    public required TimeSpan MultipleDimensionReplyTimeout { get; init; }
-
-    /// <summary>
-    /// Gets or sets the reply timeout used when multiple status replies should be returned.
-    /// </summary>
-    public required TimeSpan MultipleStatusReplyTimeout { get; init; }
-
-    /// <summary>
-    /// Gets or sets the outgoing message processing timeout.
-    /// </summary>
-    public required TimeSpan OutgoingMessageProcessingTimeout { get; init; }
-
-    /// <summary>
-    /// Gets or sets the post-sending delay, if applicable.
-    /// </summary>
-    public required TimeSpan PostSendingDelay { get; init; }
-
-    /// <summary>
-    /// Gets or sets the reply timeout used when a single dimension should be returned.
-    /// </summary>
-    public required TimeSpan UniqueDimensionReplyTimeout { get; init; }
-
-    /// <summary>
-    /// Gets or sets the reply timeout used when a unique status reply should be returned.
-    /// </summary>
-    public required TimeSpan UniqueStatusReplyTimeout { get; init; }
-
-    /// <summary>
-    /// Gets or sets the <see cref="ResiliencePipeline"/> used to manage sessions.
-    /// </summary>
-    public required ResiliencePipeline SessionResiliencePipeline { get; init; }
-
-    /// <summary>
-    /// Gets or sets the <see cref="ResiliencePipeline"/> used to send an outgoing message.
-    /// </summary>
-    public required ResiliencePipeline OutgoingMessageResiliencePipeline { get; init; }
+    public required OpenNettyWorkerOptions DefaultWorkerOptions { get; init; }
 
     /// <summary>
     /// Creates a default instance of the <see cref="OpenNettyGatewayOptions"/>
@@ -97,208 +38,9 @@ public sealed record class OpenNettyGatewayOptions
 
         return new()
         {
-            ActionValidationTimeout          = device.Definition.Protocol is OpenNettyProtocol.Nitoo ? TimeSpan.FromSeconds(2) : TimeSpan.Zero,
-            CommandSessionMaximumLifetime    = device.Definition.Protocol is OpenNettyProtocol.Scs ? TimeSpan.FromSeconds(20) : TimeSpan.Zero,
-            ConnectionNegotiationTimeout     = TimeSpan.FromSeconds(10),
-            EnableSupervisionMode            = device.Definition.HasCapability(OpenNettyCapabilities.ZigbeeSupervision),
-            FrameAcknowledgementTimeout      = TimeSpan.FromSeconds(5),
-            MaximumConcurrentCommandSessions = device.Definition.Protocol is OpenNettyProtocol.Scs ? (byte) 3 : (byte) 0,
-            MultipleDimensionReplyTimeout    = device.Definition.Protocol is OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee ? TimeSpan.FromSeconds(10) : TimeSpan.Zero,
-            MultipleStatusReplyTimeout       = device.Definition.Protocol is OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee ? TimeSpan.FromSeconds(10) : TimeSpan.Zero,
-            OutgoingMessageProcessingTimeout = TimeSpan.FromSeconds(10),
-            PostSendingDelay                 = device.Definition.Protocol is OpenNettyProtocol.Nitoo ? TimeSpan.FromMilliseconds(150) : TimeSpan.Zero,
-            UniqueDimensionReplyTimeout      = TimeSpan.FromSeconds(2),
-            UniqueStatusReplyTimeout         = TimeSpan.FromSeconds(2),
-
-            OutgoingMessageResiliencePipeline = new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
-            {
-                DelayGenerator = static arguments =>
-                {
-                    if (!arguments.Context.Properties.TryGetValue(
-                        key  : new ResiliencePropertyKey<OpenNettyTransmissionOptions>(nameof(OpenNettyTransmissionOptions)),
-                        value: out OpenNettyTransmissionOptions options))
-                    {
-                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
-                    }
-
-                    // If the post-sending delay was disabled for this transmission,
-                    // use longer pause times when retrying to send a message.
-                    if (options.HasFlag(OpenNettyTransmissionOptions.DisablePostSendingDelay))
-                    {
-                        return new(arguments.AttemptNumber switch
-                        {
-                            0 => TimeSpan.FromMilliseconds(200),
-                            1 => TimeSpan.FromMilliseconds(500),
-                            _ => TimeSpan.FromMilliseconds(1_000)
-                        });
-                    }
-
-                    return new(arguments.AttemptNumber switch
-                    {
-                        0 => TimeSpan.FromMilliseconds(100),
-                        1 => TimeSpan.FromMilliseconds(300),
-                        _ => TimeSpan.FromMilliseconds(800)
-                    });
-                },
-                // Note: this setting is deliberately set to the maximum value allowed
-                // to be able to define it dynamically in the ShouldHandle delegate.
-                MaxRetryAttempts = int.MaxValue,
-                ShouldHandle = static arguments =>
-                {
-                    if (!arguments.Context.Properties.TryGetValue(
-                        key  : new ResiliencePropertyKey<OpenNettyGateway>(nameof(OpenNettyGateway)),
-                        value: out OpenNettyGateway? gateway))
-                    {
-                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
-                    }
-
-                    if (!arguments.Context.Properties.TryGetValue(
-                        key  : new ResiliencePropertyKey<ILogger<OpenNettyService>>(nameof(ILogger<>)),
-                        value: out ILogger<OpenNettyService>? logger))
-                    {
-                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
-                    }
-
-                    if (!arguments.Context.Properties.TryGetValue(
-                        key  : new ResiliencePropertyKey<OpenNettyMessage>(nameof(OpenNettyMessage)),
-                        value: out OpenNettyMessage? message))
-                    {
-                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
-                    }
-
-                    if (!arguments.Context.Properties.TryGetValue(
-                        key  : new ResiliencePropertyKey<OpenNettyTransmissionOptions>(nameof(OpenNettyTransmissionOptions)),
-                        value: out OpenNettyTransmissionOptions options))
-                    {
-                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
-                    }
-
-                    // Never retransmit a message if no exception was thrown.
-                    if (arguments.Outcome.Exception is null)
-                    {
-                        return ValueTask.FromResult(false);
-                    }
-
-                    logger.LogInformation(6016, arguments.Outcome.Exception, SR.GetResourceString(SR.ID6016), gateway, message);
-
-                    return ValueTask.FromResult(arguments.Outcome.Exception switch
-                    {
-                        // Nitoo gateways are known for returning NACK frames when sending multiple messages
-                        // in a row. In this case, always retry sending the message 3 times before giving up.
-                        OpenNettyException { ErrorCode: OpenNettyErrorCode.InvalidFrame }
-                            when message.Protocol is OpenNettyProtocol.Nitoo => arguments.AttemptNumber is < 3,
-
-                        // In large Zigbee networks, Zigbee gateways can sometimes return BUSY NACK frames
-                        // when the network is overloaded (e.g when sending multiple broadcast frames).
-                        // In this case, always retry sending the message twice before giving up.
-                        OpenNettyException { ErrorCode: OpenNettyErrorCode.InvalidFrame or OpenNettyErrorCode.GatewayBusy }
-                            when message.Protocol is OpenNettyProtocol.Zigbee => arguments.AttemptNumber is < 2,
-
-                        // SCS gateways are less easily overloaded. As such, retry sending the message only once before giving up.
-                        OpenNettyException { ErrorCode: OpenNettyErrorCode.InvalidFrame }
-                            when message.Protocol is OpenNettyProtocol.Scs => arguments.AttemptNumber is < 1,
-
-                        // For messages sent via powerline or radio (that are prone to interference), always retry
-                        // twice if the error was caused by a missing reply from the end device, unless the sender
-                        // explicitly specified that unsafe retransmissions are not allowed for this message.
-                        OpenNettyException { ErrorCode: OpenNettyErrorCode.NoActionReceived    or
-                                                        OpenNettyErrorCode.NoDimensionReceived or
-                                                        OpenNettyErrorCode.NoStatusReceived }
-                            when message.Medium is OpenNettyMedium.Powerline or OpenNettyMedium.Radio
-                            => arguments.AttemptNumber is < 2 && !options.HasFlag(OpenNettyTransmissionOptions.DisallowRetransmissions),
-
-                        // For messages sent via a dedicated bus, retry only once if the error was caused
-                        // by a missing reply from the end device, unless the sender explicitly specified
-                        // that unsafe retransmissions are not allowed for this message.
-                        OpenNettyException { ErrorCode: OpenNettyErrorCode.InvalidFrame or OpenNettyErrorCode.GatewayBusy }
-                            when message.Medium is OpenNettyMedium.Bus
-                            => arguments.AttemptNumber is < 1 && !options.HasFlag(OpenNettyTransmissionOptions.DisallowRetransmissions),
-
-                        _ => false
-                    });
-                },
-                OnRetry = static arguments =>
-                {
-                    if (!arguments.Context.Properties.TryGetValue(
-                        key  : new ResiliencePropertyKey<OpenNettyGateway>(nameof(OpenNettyGateway)),
-                        value: out OpenNettyGateway? gateway))
-                    {
-                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
-                    }
-
-                    if (!arguments.Context.Properties.TryGetValue(
-                        key  : new ResiliencePropertyKey<ILogger<OpenNettyService>>(nameof(ILogger<>)),
-                        value: out ILogger<OpenNettyService>? logger))
-                    {
-                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
-                    }
-
-                    if (!arguments.Context.Properties.TryGetValue(
-                        key  : new ResiliencePropertyKey<OpenNettyMessage>(nameof(OpenNettyMessage)),
-                        value: out OpenNettyMessage? message))
-                    {
-                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
-                    }
-
-                    logger.LogInformation(6017, SR.GetResourceString(SR.ID6017), gateway, message, (uint) arguments.AttemptNumber + 1);
-
-                    return ValueTask.CompletedTask;
-                }
-            }).Build(),
-
-            SessionResiliencePipeline = new ResiliencePipelineBuilder()
-                .AddRetry(new RetryStrategyOptions
-                {
-                    MaxRetryAttempts = int.MaxValue,
-                    ShouldHandle = static arguments => ValueTask.FromResult(
-                        !arguments.Context.CancellationToken.IsCancellationRequested)
-                })
-                .AddRetry(new RetryStrategyOptions
-                {
-                    DelayGenerator = static arguments => new(arguments.AttemptNumber switch
-                    {
-                        0      or      1 => TimeSpan.FromSeconds(1),
-                        2      or      3 => TimeSpan.FromSeconds(5),
-                        4      or      5 => TimeSpan.FromSeconds(10),
-                        6 or 7 or 8 or 9 => TimeSpan.FromSeconds(30),
-                               _         => TimeSpan.FromSeconds(60)
-                    }),
-                    MaxRetryAttempts = int.MaxValue,
-                    ShouldHandle = static arguments =>
-                    {
-                        if (!arguments.Context.Properties.TryGetValue(
-                            key  : new ResiliencePropertyKey<OpenNettyGateway>(nameof(OpenNettyGateway)),
-                            value: out OpenNettyGateway? gateway))
-                        {
-                            throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
-                        }
-
-                        if (!arguments.Context.Properties.TryGetValue(
-                            key  : new ResiliencePropertyKey<ILogger<OpenNettyWorker>>(nameof(ILogger<>)),
-                            value: out ILogger<OpenNettyWorker>? logger))
-                        {
-                            throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
-                        }
-
-                        if (!arguments.Context.Properties.TryGetValue(
-                            key  : new ResiliencePropertyKey<OpenNettySessionType>(nameof(OpenNettySessionType)),
-                            value: out OpenNettySessionType type))
-                        {
-                            throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
-                        }
-
-                        if (arguments.Outcome.Exception is not Exception exception)
-                        {
-                            return ValueTask.FromResult(false);
-                        }
-
-                        logger.LogInformation(6020, exception, SR.GetResourceString(SR.ID6020), type, gateway);
-
-                        // Always recreate new sessions on failed attempts, unless the operation was canceled by the worker.
-                        return ValueTask.FromResult(!arguments.Context.CancellationToken.IsCancellationRequested);
-                    }
-                })
-                .Build()
+            DefaultSessionOptions      = OpenNettySessionOptions.CreateDefaults(device),
+            DefaultTransmissionOptions = OpenNettyTransmissionOptions.CreateDefaults(device),
+            DefaultWorkerOptions       = OpenNettyWorkerOptions.CreateDefaults(device),
         };
     }
 }

--- a/src/OpenNetty/OpenNettyHostedService.cs
+++ b/src/OpenNetty/OpenNettyHostedService.cs
@@ -107,7 +107,8 @@ public sealed class OpenNettyHostedService : BackgroundService
                 }, stoppingToken));
 
                 // Ask the worker to process incoming and outgoing notifications for this gateway.
-                tasks.Add(_worker.ProcessNotificationsAsync(gateway, output.Reader, input.Writer, stoppingToken));
+                tasks.Add(_worker.ProcessNotificationsAsync(gateway,
+                    gateway.Options.DefaultWorkerOptions, output.Reader, input.Writer, stoppingToken));
             }
 
             // Connect the observable instances to allow observers to start processing notifications.

--- a/src/OpenNetty/OpenNettyResources.resx
+++ b/src/OpenNetty/OpenNettyResources.resx
@@ -147,18 +147,6 @@
   <data name="ID0010" xml:space="preserve">
     <value>The protocol attached to the message isn't valid.</value>
   </data>
-  <data name="ID0011" xml:space="preserve">
-    <value>Action validation is only supported by Nitoo devices.</value>
-  </data>
-  <data name="ID0012" xml:space="preserve">
-    <value>Action validation is only supported for BUS COMMAND and DIMENSION SET messages.</value>
-  </data>
-  <data name="ID0013" xml:space="preserve">
-    <value>Action validation is only supported for unicast transmissions.</value>
-  </data>
-  <data name="ID0014" xml:space="preserve">
-    <value>Action validation is only supported when specifying a destination address.</value>
-  </data>
   <data name="ID0015" xml:space="preserve">
     <value>A message is already being sent by this session.</value>
   </data>
@@ -450,6 +438,9 @@
   <data name="ID0119" xml:space="preserve">
     <value>An endpoint name must be explicitly attached to SCS light point endpoints.</value>
   </data>
+  <data name="ID0120" xml:space="preserve">
+    <value>No gateway compatible with the '{0}' protocol could be found in the options.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The endpoint name '{0}' is not valid. Endpoint names cannot contain the '+' or '*' characters.</value>
   </data>
@@ -479,6 +470,12 @@
   </data>
   <data name="ID2009" xml:space="preserve">
     <value>The MQTT root and Home Assistant discovery topics cannot be set to the same value.</value>
+  </data>
+  <data name="ID2010" xml:space="preserve">
+    <value>Action validation is only supported by Nitoo devices.</value>
+  </data>
+  <data name="ID2011" xml:space="preserve">
+    <value>Action validation is only supported for endpoints that have an address attached.</value>
   </data>
   <data name="ID6000" xml:space="preserve">
     <value>The OpenNetty hosted service is starting.</value>

--- a/src/OpenNetty/OpenNettyService.cs
+++ b/src/OpenNetty/OpenNettyService.cs
@@ -48,7 +48,7 @@ public class OpenNettyService : IOpenNettyService
         OpenNettyMedium? medium = null,
         OpenNettyMode? mode = null,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         if (!Enum.IsDefined(protocol))
@@ -69,12 +69,13 @@ public class OpenNettyService : IOpenNettyService
         // If no gateway was explicitly specified, try to resolve it from the options.
         gateway ??= _options.CurrentValue.Gateways.Find(gateway => gateway.Protocol == protocol) ??
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0032));
+        options ??= gateway.Options.DefaultTransmissionOptions;
 
         var message = OpenNettyMessage.CreateDimensionRequest(protocol, dimension, address, medium, mode);
 
         // Note: acknowledgement validation is deliberately disabled while sending the DIMENSION REQUEST frame
         // as it's used by the OWN gateway to indicate when it's done pushing additional DIMENSION READ frames.
-        options |= OpenNettyTransmissionOptions.IgnoreAcknowledgementValidation;
+        options = options with { IgnoreAcknowledgementValidation = true };
 
         var context = ResilienceContextPool.Shared.Get(cancellationToken);
         context.Properties.Set(new ResiliencePropertyKey<OpenNettyGateway>(nameof(OpenNettyGateway)), gateway);
@@ -129,7 +130,7 @@ public class OpenNettyService : IOpenNettyService
 
         try
         {
-            session = await gateway.Options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
+            session = await options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
                 await DispatchMessageAsync(message, gateway, options, context.CancellationToken), context);
         }
 
@@ -141,7 +142,7 @@ public class OpenNettyService : IOpenNettyService
         await foreach (var notification in notifications
             .Where(notification => notification.Session == session)
             .OfType<(OpenNettySession Session, OpenNettyMessage Message), (OpenNettySession Session, OpenNettyMessage Message)?>()
-            .Timeout(gateway.Options.MultipleDimensionReplyTimeout, AsyncObservable.Return<(OpenNettySession Session, OpenNettyMessage Message)?>(null))
+            .Timeout(options.MultipleDimensionReplyTimeout, AsyncObservable.Return<(OpenNettySession Session, OpenNettyMessage Message)?>(null))
             .ToAsyncEnumerable())
         {
             switch (notification?.Message.Type)
@@ -169,7 +170,7 @@ public class OpenNettyService : IOpenNettyService
         OpenNettyMode? mode = null,
         Func<OpenNettyCommand, ValueTask<bool>>? filter = null,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         if (!Enum.IsDefined(protocol))
@@ -190,12 +191,13 @@ public class OpenNettyService : IOpenNettyService
         // If no gateway was explicitly specified, try to resolve it from the options.
         gateway ??= _options.CurrentValue.Gateways.Find(gateway => gateway.Protocol == protocol) ??
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0032));
+        options ??= gateway.Options.DefaultTransmissionOptions;
 
         var message = OpenNettyMessage.CreateStatusRequest(protocol, category, address, medium, mode);
 
         // Note: acknowledgement validation is deliberately disabled while sending the STATUS REQUEST frame
         // as it's used by the gateway to indicate when it's done pushing additional BUS COMMAND frames.
-        options |= OpenNettyTransmissionOptions.IgnoreAcknowledgementValidation;
+        options = options with { IgnoreAcknowledgementValidation = true };
 
         var context = ResilienceContextPool.Shared.Get(cancellationToken);
         context.Properties.Set(new ResiliencePropertyKey<OpenNettyGateway>(nameof(OpenNettyGateway)), gateway);
@@ -254,7 +256,7 @@ public class OpenNettyService : IOpenNettyService
 
         try
         {
-            session = await gateway.Options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
+            session = await options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
                 await DispatchMessageAsync(message, gateway, options, context.CancellationToken), context);
         }
 
@@ -266,7 +268,7 @@ public class OpenNettyService : IOpenNettyService
         await foreach (var notification in notifications
             .Where(notification => notification.Session == session)
             .OfType<(OpenNettySession Session, OpenNettyMessage Message), (OpenNettySession Session, OpenNettyMessage Message)?>()
-            .Timeout(gateway.Options.MultipleStatusReplyTimeout, AsyncObservable.Return<(OpenNettySession Session, OpenNettyMessage Message)?>(null))
+            .Timeout(options.MultipleStatusReplyTimeout, AsyncObservable.Return<(OpenNettySession Session, OpenNettyMessage Message)?>(null))
             .ToAsyncEnumerable())
         {
             switch (notification?.Message.Type)
@@ -293,7 +295,7 @@ public class OpenNettyService : IOpenNettyService
         OpenNettyMedium? medium = null,
         OpenNettyMode? mode = null,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default)
     {
         if (!Enum.IsDefined(protocol))
@@ -309,6 +311,7 @@ public class OpenNettyService : IOpenNettyService
         // If no gateway was explicitly specified, try to resolve it from the options.
         gateway ??= _options.CurrentValue.Gateways.Find(gateway => gateway.Protocol == protocol) ??
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0032));
+        options ??= gateway.Options.DefaultTransmissionOptions;
 
         var message = OpenNettyMessage.CreateCommand(protocol, command, address, medium, mode);
 
@@ -320,7 +323,7 @@ public class OpenNettyService : IOpenNettyService
 
         try
         {
-            await gateway.Options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
+            await options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
                 await DispatchMessageAsync(message, gateway, options, context.CancellationToken), context);
         }
 
@@ -338,7 +341,7 @@ public class OpenNettyService : IOpenNettyService
         OpenNettyMedium? medium = null,
         OpenNettyMode? mode = null,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default)
     {
         if (!Enum.IsDefined(protocol))
@@ -354,6 +357,7 @@ public class OpenNettyService : IOpenNettyService
         // If no gateway was explicitly specified, try to resolve it from the options.
         gateway ??= _options.CurrentValue.Gateways.Find(gateway => gateway.Protocol == protocol) ??
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0032));
+        options ??= gateway.Options.DefaultTransmissionOptions;
 
         var message = OpenNettyMessage.CreateDimensionRequest(protocol, dimension, address, medium, mode);
 
@@ -392,14 +396,14 @@ public class OpenNettyService : IOpenNettyService
 
         try
         {
-            return await gateway.Options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
+            return await options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
             {
                 var session = await DispatchMessageAsync(message, gateway, options, context.CancellationToken);
 
                 return (await notifications
                     .FirstOrDefault(notification => notification.Session == session)
                     .OfType<(OpenNettySession Session, OpenNettyMessage Message), (OpenNettySession Session, OpenNettyMessage Message)?>()
-                    .Timeout(gateway.Options.UniqueDimensionReplyTimeout, AsyncObservable.Return<(OpenNettySession Session, OpenNettyMessage Message)?>(null))
+                    .Timeout(options.UniqueDimensionReplyTimeout, AsyncObservable.Return<(OpenNettySession Session, OpenNettyMessage Message)?>(null))
                     .RunAsync(cancellationToken))?.Message.Values ?? throw new OpenNettyException(
                         OpenNettyErrorCode.NoDimensionReceived, SR.GetResourceString(SR.ID0033));
             }, context);
@@ -420,7 +424,7 @@ public class OpenNettyService : IOpenNettyService
         OpenNettyMode? mode = null,
         Func<OpenNettyCommand, ValueTask<bool>>? filter = null,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default)
     {
         if (!Enum.IsDefined(protocol))
@@ -436,6 +440,7 @@ public class OpenNettyService : IOpenNettyService
         // If no gateway was explicitly specified, try to resolve it from the options.
         gateway ??= _options.CurrentValue.Gateways.Find(gateway => gateway.Protocol == protocol) ??
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0032));
+        options ??= gateway.Options.DefaultTransmissionOptions;
 
         var message = OpenNettyMessage.CreateStatusRequest(protocol, category, address, medium, mode);
 
@@ -478,14 +483,14 @@ public class OpenNettyService : IOpenNettyService
 
         try
         {
-            return await gateway.Options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
+            return await options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
             {
                 var session = await DispatchMessageAsync(message, gateway, options, context.CancellationToken);
 
                 return (await notifications
                     .FirstOrDefault(notification => notification.Session == session)
                     .OfType<(OpenNettySession Session, OpenNettyMessage Message), (OpenNettySession Session, OpenNettyMessage Message)?>()
-                    .Timeout(gateway.Options.UniqueStatusReplyTimeout, AsyncObservable.Return<(OpenNettySession Session, OpenNettyMessage Message)?>(null))
+                    .Timeout(options.UniqueStatusReplyTimeout, AsyncObservable.Return<(OpenNettySession Session, OpenNettyMessage Message)?>(null))
                     .RunAsync(cancellationToken))?.Message.Command ?? throw new OpenNettyException(
                         OpenNettyErrorCode.NoStatusReceived, SR.GetResourceString(SR.ID0034));
             }, context);
@@ -502,7 +507,7 @@ public class OpenNettyService : IOpenNettyService
     public virtual IAsyncObservable<OpenNettyMessage> ObserveMessagesAsync(
         OpenNettyMessage message,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(message);
@@ -515,6 +520,7 @@ public class OpenNettyService : IOpenNettyService
         // If no gateway was explicitly specified, try to resolve it from the options.
         gateway ??= _options.CurrentValue.Gateways.Find(gateway => gateway.Protocol == message.Protocol) ??
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0032));
+        options ??= gateway.Options.DefaultTransmissionOptions;
 
         return AsyncObservable.Create<OpenNettyMessage>(async observer =>
         {
@@ -542,7 +548,7 @@ public class OpenNettyService : IOpenNettyService
 
             try
             {
-                session = await gateway.Options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
+                session = await options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
                     await DispatchMessageAsync(message, gateway, options, context.CancellationToken), context);
             }
 
@@ -565,7 +571,7 @@ public class OpenNettyService : IOpenNettyService
     public virtual async ValueTask SendMessageAsync(
         OpenNettyMessage message,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(message);
@@ -578,6 +584,7 @@ public class OpenNettyService : IOpenNettyService
         // If no gateway was explicitly specified, try to resolve it from the options.
         gateway ??= _options.CurrentValue.Gateways.Find(gateway => gateway.Protocol == message.Protocol) ??
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0032));
+        options ??= gateway.Options.DefaultTransmissionOptions;
 
         var context = ResilienceContextPool.Shared.Get(cancellationToken);
         context.Properties.Set(new ResiliencePropertyKey<OpenNettyGateway>(nameof(OpenNettyGateway)), gateway);
@@ -587,7 +594,7 @@ public class OpenNettyService : IOpenNettyService
 
         try
         {
-            await gateway.Options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
+            await options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
                 await DispatchMessageAsync(message, gateway, options, context.CancellationToken), context);
         }
 
@@ -606,7 +613,7 @@ public class OpenNettyService : IOpenNettyService
         OpenNettyMedium? medium = null,
         OpenNettyMode? mode = null,
         OpenNettyGateway? gateway = null,
-        OpenNettyTransmissionOptions options = OpenNettyTransmissionOptions.None,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default)
     {
         if (!Enum.IsDefined(protocol))
@@ -622,6 +629,7 @@ public class OpenNettyService : IOpenNettyService
         // If no gateway was explicitly specified, try to resolve it from the options.
         gateway ??= _options.CurrentValue.Gateways.Find(gateway => gateway.Protocol == protocol) ??
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0032));
+        options ??= gateway.Options.DefaultTransmissionOptions;
 
         var message = OpenNettyMessage.CreateDimensionSet(protocol, dimension, values, address, medium, mode);
 
@@ -633,7 +641,7 @@ public class OpenNettyService : IOpenNettyService
 
         try
         {
-            await gateway.Options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
+            await options.OutgoingMessageResiliencePipeline.ExecuteAsync(async context =>
                 await DispatchMessageAsync(message, gateway, options, context.CancellationToken), context);
         }
 
@@ -680,7 +688,7 @@ public class OpenNettyService : IOpenNettyService
                 when dimension == OpenNettyDimensions.Management.FirmwareVersion ||
                      dimension == OpenNettyDimensions.Management.HardwareVersion ||
                      dimension == OpenNettyDimensions.Management.DeviceIdentifier:
-                options |= OpenNettyTransmissionOptions.IgnoreAcknowledgementValidation;
+                options = options with { IgnoreAcknowledgementValidation = true };
                 break;
         }
 
@@ -722,7 +730,7 @@ public class OpenNettyService : IOpenNettyService
         // If no notification is received, assume the message couldn't be processed by a worker.
         switch (await notifications
             .FirstOrDefault()
-            .Timeout(gateway.Options.OutgoingMessageProcessingTimeout, AsyncObservable.Return(default(OpenNettyNotification)))
+            .Timeout(options.OutgoingMessageProcessingTimeout, AsyncObservable.Return(default(OpenNettyNotification)))
             .RunAsync(cancellationToken))
         {
             case OpenNettyNotifications.MessageSent { Session: OpenNettySession session }:

--- a/src/OpenNetty/OpenNettySession.cs
+++ b/src/OpenNetty/OpenNettySession.cs
@@ -132,7 +132,7 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
     /// <exception cref="OpenNettyException">An error occurred while sending the message.</exception>
     public async ValueTask SendAsync(
         OpenNettyMessage message,
-        OpenNettyTransmissionOptions options = default,
+        OpenNettyTransmissionOptions? options = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(message, nameof(message));
@@ -147,28 +147,8 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0010));
         }
 
-        if (options.HasFlag(OpenNettyTransmissionOptions.RequireActionValidation))
-        {
-            if (message.Protocol is not OpenNettyProtocol.Nitoo)
-            {
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0011));
-            }
-
-            if (message.Address is null)
-            {
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0014));
-            }
-
-            if (message.Type is not (OpenNettyMessageType.BusCommand or OpenNettyMessageType.DimensionSet))
-            {
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0012));
-            }
-
-            if (message.Mode is OpenNettyMode.Broadcast or OpenNettyMode.Multicast)
-            {
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0013));
-            }
-        }
+        // If no explicit transmissions options were specified, resolve them from the gateway options.
+        options ??= _gateway.Options.DefaultTransmissionOptions;
 
         if (!await _semaphore.WaitAsync(TimeSpan.Zero, cancellationToken))
         {
@@ -184,19 +164,19 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
                 {
                     { Protocol: OpenNettyProtocol.Nitoo or OpenNettyProtocol.Scs,
                       Type    : OpenNettyMessageType.Acknowledgement or OpenNettyMessageType.NegativeAcknowledgement }
-                        when !options.HasFlag(OpenNettyTransmissionOptions.IgnoreAcknowledgementValidation) => true,
+                        when !options.IgnoreAcknowledgementValidation => true,
 
                     { Protocol: OpenNettyProtocol.Zigbee,
                       Type    : OpenNettyMessageType.Acknowledgement             or
                                 OpenNettyMessageType.BusyNegativeAcknowledgement or
                                 OpenNettyMessageType.NegativeAcknowledgement }
-                        when !options.HasFlag(OpenNettyTransmissionOptions.IgnoreAcknowledgementValidation) => true,
+                        when !options.IgnoreAcknowledgementValidation => true,
 
                     { Protocol: OpenNettyProtocol.Nitoo, 
                       Type    : OpenNettyMessageType.BusCommand,
                       Command : OpenNettyCommand command,
                       Address : OpenNettyAddress }
-                        when options.HasFlag(OpenNettyTransmissionOptions.RequireActionValidation) &&
+                        when !options.IgnoreActionValidation && IsActionValidationSupported(message) &&
                             (command == OpenNettyCommands.Diagnostics.ValidAction ||
                              command == OpenNettyCommands.Diagnostics.InvalidAction) &&
                              message.Address == address => true,
@@ -211,13 +191,13 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
             {
                 await connection.SendAsync(message.Frame, cancellationToken);
 
-                if (!options.HasFlag(OpenNettyTransmissionOptions.IgnoreAcknowledgementValidation))
+                if (!options.IgnoreAcknowledgementValidation)
                 {
                     switch (await messages
                         .FirstOrDefault(static message => message.Type is OpenNettyMessageType.Acknowledgement             or
                                                                           OpenNettyMessageType.BusyNegativeAcknowledgement or
                                                                           OpenNettyMessageType.NegativeAcknowledgement)
-                        .Timeout(_gateway.Options.FrameAcknowledgementTimeout, AsyncObservable.Return<OpenNettyMessage?>(null))
+                        .Timeout(options.FrameAcknowledgementTimeout, AsyncObservable.Return<OpenNettyMessage?>(null))
                         .RunAsync(cancellationToken))
                     {
                         case null:
@@ -231,14 +211,14 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
                     }
                 }
 
-                if (options.HasFlag(OpenNettyTransmissionOptions.RequireActionValidation))
+                if (!options.IgnoreActionValidation && IsActionValidationSupported(message))
                 {
                     switch (await messages
                         .FirstOrDefault(static message =>
                             message.Type is OpenNettyMessageType.BusCommand &&
                            (message.Command == OpenNettyCommands.Diagnostics.ValidAction ||
                             message.Command == OpenNettyCommands.Diagnostics.InvalidAction))
-                        .Timeout(_gateway.Options.ActionValidationTimeout, AsyncObservable.Return<OpenNettyMessage?>(null))
+                        .Timeout(options.ActionValidationTimeout, AsyncObservable.Return<OpenNettyMessage?>(null))
                         .RunAsync(cancellationToken))
                     {
                         case null:
@@ -251,10 +231,9 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
             }
 
             // If the gateway options indicate that a post-sending delay must be enforced, apply it immediately.
-            if (_gateway.Options.PostSendingDelay != TimeSpan.Zero &&
-                !options.HasFlag(OpenNettyTransmissionOptions.DisablePostSendingDelay))
+            if (options.PostSendingDelay != TimeSpan.Zero)
             {
-                await Task.Delay(_gateway.Options.PostSendingDelay, cancellationToken);
+                await Task.Delay(options.PostSendingDelay, cancellationToken);
             }
         }
 
@@ -262,6 +241,13 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
         {
             _semaphore.Release();
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+        static bool IsActionValidationSupported(OpenNettyMessage message) => message is {
+            Protocol: OpenNettyProtocol.Nitoo,
+            Address : not null,
+            Mode    : OpenNettyMode.Unicast,
+            Type    : OpenNettyMessageType.BusCommand or OpenNettyMessageType.DimensionSet };
     }
 
     /// <summary>
@@ -269,6 +255,7 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
     /// </summary>
     /// <param name="gateway">The gateway.</param>
     /// <param name="type">The session type.</param>
+    /// <param name="options">The session options.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>
     /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the
@@ -278,7 +265,8 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
     /// <exception cref="ArgumentOutOfRangeException">The session type is invalid.</exception>
     /// <exception cref="OpenNettyException">An error occurred while establishing the session.</exception>
     public static async ValueTask<OpenNettySession> CreateAsync(
-        OpenNettyGateway gateway, OpenNettySessionType type, CancellationToken cancellationToken = default)
+        OpenNettyGateway gateway, OpenNettySessionType type,
+        OpenNettySessionOptions? options = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(gateway);
 
@@ -295,9 +283,11 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
 
         using var source = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-        if (gateway.Options.ConnectionNegotiationTimeout != Timeout.InfiniteTimeSpan)
+        options ??= gateway.Options.DefaultSessionOptions;
+
+        if (options.ConnectionNegotiationTimeout != Timeout.InfiniteTimeSpan)
         {
-            source.CancelAfter(gateway.Options.ConnectionNegotiationTimeout);
+            source.CancelAfter(options.ConnectionNegotiationTimeout);
         }
 
         // Create a new connection that will be managed by the returned object.
@@ -305,96 +295,63 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
 
         try
         {
+            // Ask the gateway to return its firmware version to ensure the connection is working properly.
             if (type is OpenNettySessionType.Generic)
             {
-                // If the supervision mode was enabled, enforce it when creating the session to ensure the
-                // connection is working properly and receive all the state changes sent by the devices.
-                if (gateway.Options.EnableSupervisionMode)
+                await connection.SendAsync(new OpenNettyFrame(
+                    new OpenNettyField(OpenNettyParameter.Empty, new OpenNettyParameter("13")),
+                    new OpenNettyField(OpenNettyParameter.Empty),
+                    new OpenNettyField(new OpenNettyParameter("16"))), source.Token);
+
+                try
                 {
-                    await connection.SendAsync(new OpenNettyFrame(
-                        new OpenNettyField(new OpenNettyParameter("13")),
-                        new OpenNettyField(new OpenNettyParameter("66")),
-                        new OpenNettyField(OpenNettyParameter.Empty)), source.Token);
-
-                    try
+                    if (gateway.Protocol is OpenNettyProtocol.Nitoo)
                     {
-                        // Ensure the server acknowledged the supervision mode request.
-                        var frame = await WaitFrameAsync(connection, static frame =>
-                            frame == OpenNettyFrames.Acknowledgement ||
-                            frame == OpenNettyFrames.NegativeAcknowledgement ||
-                            frame == OpenNettyFrames.BusyNegativeAcknowledgement, source.Token)
-                            ?? throw new OpenNettyException(OpenNettyErrorCode.ConnectionClosed, SR.GetResourceString(SR.ID0113));
-
-                        if (frame != OpenNettyFrames.Acknowledgement)
+                        // Note: Nitoo gateways do not return acknowledgement frames for firmware version requests.
+                        if (await WaitFrameAsync(connection, IsFirmwareVersion, source.Token) is null)
                         {
-                            throw new OpenNettyException(OpenNettyErrorCode.InvalidFrame, SR.GetResourceString(SR.ID0109));
+                            throw new OpenNettyException(OpenNettyErrorCode.ConnectionClosed, SR.GetResourceString(SR.ID0113));
                         }
                     }
 
-                    catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                    else
                     {
-                        throw new OpenNettyException(OpenNettyErrorCode.InvalidFrame, SR.GetResourceString(SR.ID0109));
+                        // Note: unlike Nitoo gateways, Zigbee gateways always acknowledge firmware version requests.
+                        switch (await WaitFrameAsync(connection, static frame =>
+                            frame == OpenNettyFrames.Acknowledgement ||
+                            frame == OpenNettyFrames.BusyNegativeAcknowledgement ||
+                            frame == OpenNettyFrames.NegativeAcknowledgement || IsFirmwareVersion(frame), source.Token))
+                        {
+                            case null:
+                                throw new OpenNettyException(OpenNettyErrorCode.ConnectionClosed, SR.GetResourceString(SR.ID0113));
+
+                            case OpenNettyFrame frame when frame == OpenNettyFrames.BusyNegativeAcknowledgement ||
+                                                           frame == OpenNettyFrames.NegativeAcknowledgement:
+                                throw new OpenNettyException(OpenNettyErrorCode.InvalidFrame, SR.GetResourceString(SR.ID0114));
+
+                            case OpenNettyFrame frame when frame == OpenNettyFrames.Acknowledgement:
+                                if (await WaitFrameAsync(connection, IsFirmwareVersion, source.Token) is null)
+                                {
+                                    throw new OpenNettyException(OpenNettyErrorCode.ConnectionClosed, SR.GetResourceString(SR.ID0113));
+                                }
+                                break;
+
+                            case OpenNettyFrame frame when IsFirmwareVersion(frame):
+                                if (await WaitFrameAsync(connection, static frame =>
+                                    frame == OpenNettyFrames.Acknowledgement ||
+                                    frame == OpenNettyFrames.BusyNegativeAcknowledgement ||
+                                    frame == OpenNettyFrames.NegativeAcknowledgement, source.Token) != OpenNettyFrames.Acknowledgement)
+                                {
+                                    throw new OpenNettyException(OpenNettyErrorCode.InvalidFrame, SR.GetResourceString(SR.ID0114));
+                                }
+                                break;
+                        }
                     }
                 }
 
-                // Otherwise, ask the gateway to return its firmware version to ensure the connection is working properly.
-                else
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
                 {
-                    await connection.SendAsync(new OpenNettyFrame(
-                        new OpenNettyField(OpenNettyParameter.Empty, new OpenNettyParameter("13")),
-                        new OpenNettyField(OpenNettyParameter.Empty),
-                        new OpenNettyField(new OpenNettyParameter("16"))), source.Token);
-
-                    try
-                    {
-                        if (gateway.Protocol is OpenNettyProtocol.Nitoo)
-                        {
-                            // Note: Nitoo gateways do not return acknowledgement frames for firmware version requests.
-                            if (await WaitFrameAsync(connection, IsFirmwareVersion, source.Token) is null)
-                            {
-                                throw new OpenNettyException(OpenNettyErrorCode.ConnectionClosed, SR.GetResourceString(SR.ID0113));
-                            }
-                        }
-
-                        else
-                        {
-                            // Note: unlike Nitoo gateways, Zigbee gateways always acknowledge firmware version requests.
-                            switch (await WaitFrameAsync(connection, static frame =>
-                                frame == OpenNettyFrames.Acknowledgement ||
-                                frame == OpenNettyFrames.BusyNegativeAcknowledgement ||
-                                frame == OpenNettyFrames.NegativeAcknowledgement || IsFirmwareVersion(frame), source.Token))
-                            {
-                                case null:
-                                    throw new OpenNettyException(OpenNettyErrorCode.ConnectionClosed, SR.GetResourceString(SR.ID0113));
-
-                                case OpenNettyFrame frame when frame == OpenNettyFrames.BusyNegativeAcknowledgement ||
-                                                               frame == OpenNettyFrames.NegativeAcknowledgement:
-                                    throw new OpenNettyException(OpenNettyErrorCode.InvalidFrame, SR.GetResourceString(SR.ID0114));
-
-                                case OpenNettyFrame frame when frame == OpenNettyFrames.Acknowledgement:
-                                    if (await WaitFrameAsync(connection, IsFirmwareVersion, source.Token) is null)
-                                    {
-                                        throw new OpenNettyException(OpenNettyErrorCode.ConnectionClosed, SR.GetResourceString(SR.ID0113));
-                                    }
-                                    break;
-
-                                case OpenNettyFrame frame when IsFirmwareVersion(frame):
-                                    if (await WaitFrameAsync(connection, static frame =>
-                                        frame == OpenNettyFrames.Acknowledgement ||
-                                        frame == OpenNettyFrames.BusyNegativeAcknowledgement ||
-                                        frame == OpenNettyFrames.NegativeAcknowledgement, source.Token) != OpenNettyFrames.Acknowledgement)
-                                    {
-                                        throw new OpenNettyException(OpenNettyErrorCode.InvalidFrame, SR.GetResourceString(SR.ID0114));
-                                    }
-                                    break;
-                            }
-                        }
-                    }
-
-                    catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-                    {
-                        throw new OpenNettyException(OpenNettyErrorCode.InvalidFrame, SR.GetResourceString(SR.ID0114));
-                    }
+                    throw new OpenNettyException(OpenNettyErrorCode.InvalidFrame, SR.GetResourceString(SR.ID0114));
                 }
             }
 

--- a/src/OpenNetty/OpenNettySessionOptions.cs
+++ b/src/OpenNetty/OpenNettySessionOptions.cs
@@ -1,0 +1,97 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/opennetty/opennetty-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Retry;
+
+namespace OpenNetty;
+
+/// <summary>
+/// Provides various settings used to manage an OpenNetty session.
+/// </summary>
+public sealed record class OpenNettySessionOptions
+{
+    /// <summary>
+    /// Gets or sets the connection negotiation timeout.
+    /// </summary>
+    public required TimeSpan ConnectionNegotiationTimeout { get; init; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="ResiliencePipeline"/> used to manage sessions.
+    /// </summary>
+    public required ResiliencePipeline SessionResiliencePipeline { get; init; }
+
+    /// <summary>
+    /// Creates a default instance of the <see cref="OpenNettySessionOptions"/>
+    /// class with default options appropriate for the specified device.
+    /// </summary>
+    /// <param name="device">The device.</param>
+    /// <returns>A default instance of the <see cref="OpenNettySessionOptions"/> class.</returns>
+    public static OpenNettySessionOptions CreateDefaults(OpenNettyDevice device)
+    {
+        ArgumentNullException.ThrowIfNull(device);
+
+        return new()
+        {
+            ConnectionNegotiationTimeout = TimeSpan.FromSeconds(10),
+
+            SessionResiliencePipeline = new ResiliencePipelineBuilder()
+                .AddRetry(new RetryStrategyOptions
+                {
+                    MaxRetryAttempts = int.MaxValue,
+                    ShouldHandle = static arguments => ValueTask.FromResult(
+                        !arguments.Context.CancellationToken.IsCancellationRequested)
+                })
+                .AddRetry(new RetryStrategyOptions
+                {
+                    DelayGenerator = static arguments => new(arguments.AttemptNumber switch
+                    {
+                        0      or      1 => TimeSpan.FromSeconds(1),
+                        2      or      3 => TimeSpan.FromSeconds(5),
+                        4      or      5 => TimeSpan.FromSeconds(10),
+                        6 or 7 or 8 or 9 => TimeSpan.FromSeconds(30),
+                               _         => TimeSpan.FromSeconds(60)
+                    }),
+                    MaxRetryAttempts = int.MaxValue,
+                    ShouldHandle = static arguments =>
+                    {
+                        if (!arguments.Context.Properties.TryGetValue(
+                            key  : new ResiliencePropertyKey<OpenNettyGateway>(nameof(OpenNettyGateway)),
+                            value: out OpenNettyGateway? gateway))
+                        {
+                            throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
+                        }
+
+                        if (!arguments.Context.Properties.TryGetValue(
+                            key  : new ResiliencePropertyKey<ILogger<OpenNettyWorker>>(nameof(ILogger<>)),
+                            value: out ILogger<OpenNettyWorker>? logger))
+                        {
+                            throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
+                        }
+
+                        if (!arguments.Context.Properties.TryGetValue(
+                            key  : new ResiliencePropertyKey<OpenNettySessionType>(nameof(OpenNettySessionType)),
+                            value: out OpenNettySessionType type))
+                        {
+                            throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
+                        }
+
+                        if (arguments.Outcome.Exception is not Exception exception)
+                        {
+                            return ValueTask.FromResult(false);
+                        }
+
+                        logger.LogInformation(6020, exception, SR.GetResourceString(SR.ID6020), type, gateway);
+
+                        // Always recreate new sessions on failed attempts, unless the operation was canceled by the worker.
+                        return ValueTask.FromResult(!arguments.Context.CancellationToken.IsCancellationRequested);
+                    }
+                })
+                .Build()
+        };
+    }
+}

--- a/src/OpenNetty/OpenNettyTransmissionOptions.cs
+++ b/src/OpenNetty/OpenNettyTransmissionOptions.cs
@@ -4,37 +4,218 @@
  * the license and the contributors participating to this project.
  */
 
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Retry;
+
 namespace OpenNetty;
 
 /// <summary>
-/// Exposes common OpenNetty transmission options that can
-/// be used to control how messages are sent by a session.
+/// Provides various settings used to control how messages are sent by a session.
 /// </summary>
-[Flags]
-public enum OpenNettyTransmissionOptions
+public sealed record OpenNettyTransmissionOptions
 {
     /// <summary>
-    /// Default options.
+    /// Gets or sets the action validation timeout (Nitoo only).
     /// </summary>
-    None = 0,
+    public required TimeSpan ActionValidationTimeout { get; init; }
 
     /// <summary>
-    /// Do no wait for the gateway to return an ACK, BUSYACK or NACK frame.
+    /// Gets or sets a boolean indicating whether the message
+    /// can be replayed if an error occurs while sending it.
     /// </summary>
-    IgnoreAcknowledgementValidation = 1,
+    public required bool DisallowRetransmissions { get; init; }
 
     /// <summary>
-    /// Wait for the end device to reply with a VALID ACTION or INVALID ACTION frame (Nitoo only).
+    /// Gets or sets the frame acknowledgement timeout.
     /// </summary>
-    RequireActionValidation = 2,
+    public required TimeSpan FrameAcknowledgementTimeout { get; init; }
 
     /// <summary>
-    /// Do no add an additional delay after sending the message.
+    /// Gets or sets a boolean indicating whether OpenNetty should
+    /// wait for the gateway to return an ACK, BUSYACK or NACK frame.
     /// </summary>
-    DisablePostSendingDelay = 4,
+    public required bool IgnoreAcknowledgementValidation { get; init; }
 
     /// <summary>
-    /// Prevent the message from being replayed if an error occurs while sending it.
+    /// Gets or sets a boolean indicating whether OpenNetty should wait for the
+    /// end device to reply with a VALID ACTION or INVALID ACTION frame (Nitoo only).
     /// </summary>
-    DisallowRetransmissions = 8
+    public required bool IgnoreActionValidation { get; init; }
+
+    /// <summary>
+    /// Gets or sets the reply timeout used when multiple dimensions should be returned.
+    /// </summary>
+    public required TimeSpan MultipleDimensionReplyTimeout { get; init; }
+
+    /// <summary>
+    /// Gets or sets the reply timeout used when multiple status replies should be returned.
+    /// </summary>
+    public required TimeSpan MultipleStatusReplyTimeout { get; init; }
+
+    /// <summary>
+    /// Gets or sets the outgoing message processing timeout.
+    /// </summary>
+    public required TimeSpan OutgoingMessageProcessingTimeout { get; init; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="ResiliencePipeline"/> used to send an outgoing message.
+    /// </summary>
+    public required ResiliencePipeline OutgoingMessageResiliencePipeline { get; init; }
+
+    /// <summary>
+    /// Gets or sets the post-sending delay, if applicable.
+    /// </summary>
+    public required TimeSpan PostSendingDelay { get; init; }
+
+    /// <summary>
+    /// Gets or sets the reply timeout used when a single dimension should be returned.
+    /// </summary>
+    public required TimeSpan UniqueDimensionReplyTimeout { get; init; }
+
+    /// <summary>
+    /// Gets or sets the reply timeout used when a unique status reply should be returned.
+    /// </summary>
+    public required TimeSpan UniqueStatusReplyTimeout { get; init; }
+
+    /// <summary>
+    /// Creates a default instance of the <see cref="OpenNettyTransmissionOptions"/>
+    /// class with default options appropriate for the specified device.
+    /// </summary>
+    /// <param name="device">The device.</param>
+    /// <returns>A default instance of the <see cref="OpenNettyTransmissionOptions"/> class.</returns>
+    public static OpenNettyTransmissionOptions CreateDefaults(OpenNettyDevice device)
+    {
+        ArgumentNullException.ThrowIfNull(device);
+
+        return new()
+        {
+            ActionValidationTimeout          = device.Definition.Protocol is OpenNettyProtocol.Nitoo ? TimeSpan.FromSeconds(2) : TimeSpan.Zero,
+            DisallowRetransmissions          = false,
+            FrameAcknowledgementTimeout      = TimeSpan.FromSeconds(5),
+            IgnoreAcknowledgementValidation  = false,
+            IgnoreActionValidation           = false,
+            MultipleDimensionReplyTimeout    = device.Definition.Protocol is OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee ? TimeSpan.FromSeconds(10) : TimeSpan.Zero,
+            MultipleStatusReplyTimeout       = device.Definition.Protocol is OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee ? TimeSpan.FromSeconds(10) : TimeSpan.Zero,
+            OutgoingMessageProcessingTimeout = TimeSpan.FromSeconds(10),
+            PostSendingDelay                 = device.Definition.Protocol is OpenNettyProtocol.Nitoo ? TimeSpan.FromMilliseconds(150) : TimeSpan.Zero,
+            UniqueDimensionReplyTimeout      = TimeSpan.FromSeconds(2),
+            UniqueStatusReplyTimeout         = TimeSpan.FromSeconds(2),
+
+            OutgoingMessageResiliencePipeline = new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
+            {
+                DelayGenerator = static arguments => new(arguments.AttemptNumber switch
+                {
+                    0 => TimeSpan.FromMilliseconds(250),
+                    1 => TimeSpan.FromMilliseconds(500),
+                    _ => TimeSpan.FromMilliseconds(1_000)
+                }),
+                // Note: this setting is deliberately set to the maximum value allowed
+                // to be able to define it dynamically in the ShouldHandle delegate.
+                MaxRetryAttempts = int.MaxValue,
+                ShouldHandle = static arguments =>
+                {
+                    if (!arguments.Context.Properties.TryGetValue(
+                        key  : new ResiliencePropertyKey<OpenNettyGateway>(nameof(OpenNettyGateway)),
+                        value: out OpenNettyGateway? gateway))
+                    {
+                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
+                    }
+
+                    if (!arguments.Context.Properties.TryGetValue(
+                        key  : new ResiliencePropertyKey<ILogger<OpenNettyService>>(nameof(ILogger<>)),
+                        value: out ILogger<OpenNettyService>? logger))
+                    {
+                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
+                    }
+
+                    if (!arguments.Context.Properties.TryGetValue(
+                        key  : new ResiliencePropertyKey<OpenNettyMessage>(nameof(OpenNettyMessage)),
+                        value: out OpenNettyMessage? message))
+                    {
+                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
+                    }
+
+                    if (!arguments.Context.Properties.TryGetValue(
+                        key  : new ResiliencePropertyKey<OpenNettyTransmissionOptions>(nameof(OpenNettyTransmissionOptions)),
+                        value: out OpenNettyTransmissionOptions? options))
+                    {
+                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
+                    }
+
+                    // Never retransmit a message if no exception was thrown.
+                    if (arguments.Outcome.Exception is null)
+                    {
+                        return ValueTask.FromResult(false);
+                    }
+
+                    logger.LogInformation(6016, arguments.Outcome.Exception, SR.GetResourceString(SR.ID6016), gateway, message);
+
+                    return ValueTask.FromResult(arguments.Outcome.Exception switch
+                    {
+                        // Nitoo gateways are known for returning NACK frames when sending multiple messages
+                        // in a row. In this case, always retry sending the message 3 times before giving up.
+                        OpenNettyException { ErrorCode: OpenNettyErrorCode.InvalidFrame }
+                            when message.Protocol is OpenNettyProtocol.Nitoo => arguments.AttemptNumber is < 3,
+
+                        // In large Zigbee networks, Zigbee gateways can sometimes return BUSY NACK frames
+                        // when the network is overloaded (e.g when sending multiple broadcast frames).
+                        // In this case, always retry sending the message twice before giving up.
+                        OpenNettyException { ErrorCode: OpenNettyErrorCode.InvalidFrame or OpenNettyErrorCode.GatewayBusy }
+                            when message.Protocol is OpenNettyProtocol.Zigbee => arguments.AttemptNumber is < 2,
+
+                        // SCS gateways are less easily overloaded. As such, retry sending the message only once before giving up.
+                        OpenNettyException { ErrorCode: OpenNettyErrorCode.InvalidFrame }
+                            when message.Protocol is OpenNettyProtocol.Scs => arguments.AttemptNumber is < 1,
+
+                        // For messages sent via powerline or radio (that are prone to interference), always retry
+                        // twice if the error was caused by a missing reply from the end device, unless the sender
+                        // explicitly specified that unsafe retransmissions are not allowed for this message.
+                        OpenNettyException { ErrorCode: OpenNettyErrorCode.NoActionReceived    or
+                                                        OpenNettyErrorCode.NoDimensionReceived or
+                                                        OpenNettyErrorCode.NoStatusReceived }
+                            when message.Medium is OpenNettyMedium.Powerline or OpenNettyMedium.Radio
+                            => !options.DisallowRetransmissions && arguments.AttemptNumber is < 2,
+
+                        // For messages sent via a dedicated bus, retry only once if the error was caused
+                        // by a missing reply from the end device, unless the sender explicitly specified
+                        // that unsafe retransmissions are not allowed for this message.
+                        OpenNettyException { ErrorCode: OpenNettyErrorCode.InvalidFrame or OpenNettyErrorCode.GatewayBusy }
+                            when message.Medium is OpenNettyMedium.Bus
+                            => !options.DisallowRetransmissions && arguments.AttemptNumber is < 1,
+
+                        _ => false
+                    });
+                },
+                OnRetry = static arguments =>
+                {
+                    if (!arguments.Context.Properties.TryGetValue(
+                        key  : new ResiliencePropertyKey<OpenNettyGateway>(nameof(OpenNettyGateway)),
+                        value: out OpenNettyGateway? gateway))
+                    {
+                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
+                    }
+
+                    if (!arguments.Context.Properties.TryGetValue(
+                        key  : new ResiliencePropertyKey<ILogger<OpenNettyService>>(nameof(ILogger<>)),
+                        value: out ILogger<OpenNettyService>? logger))
+                    {
+                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
+                    }
+
+                    if (!arguments.Context.Properties.TryGetValue(
+                        key  : new ResiliencePropertyKey<OpenNettyMessage>(nameof(OpenNettyMessage)),
+                        value: out OpenNettyMessage? message))
+                    {
+                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0074));
+                    }
+
+                    logger.LogInformation(6017, SR.GetResourceString(SR.ID6017),
+                        gateway, message, (uint) arguments.AttemptNumber + 1);
+
+                    return ValueTask.CompletedTask;
+                }
+            }).Build()
+        };
+    }
 }

--- a/src/OpenNetty/OpenNettyWorker.cs
+++ b/src/OpenNetty/OpenNettyWorker.cs
@@ -29,6 +29,7 @@ public sealed class OpenNettyWorker : IOpenNettyWorker
     /// <inheritdoc/>
     public Task ProcessNotificationsAsync(
         OpenNettyGateway gateway,
+        OpenNettyWorkerOptions options,
         ChannelReader<OpenNettyNotification> reader,
         ChannelWriter<OpenNettyNotification> writer,
         CancellationToken cancellationToken)
@@ -43,20 +44,19 @@ public sealed class OpenNettyWorker : IOpenNettyWorker
 
         if (gateway.Device.Definition.Capabilities.Contains(OpenNettyCapabilities.OpenWebNetGenericSession))
         {
-            tasks.Add(CreateSharedSessionWorkerAsync(gateway, OpenNettySessionType.Generic, cancellationToken));
+            tasks.Add(CreateSharedSessionWorkerAsync(OpenNettySessionType.Generic, cancellationToken));
         }
 
         if (gateway.Device.Definition.Capabilities.Contains(OpenNettyCapabilities.OpenWebNetEventSession))
         {
-            tasks.Add(CreateSharedSessionWorkerAsync(gateway, OpenNettySessionType.Event, cancellationToken));
+            tasks.Add(CreateSharedSessionWorkerAsync(OpenNettySessionType.Event, cancellationToken));
         }
 
         if (gateway.Device.Definition.Capabilities.Contains(OpenNettyCapabilities.OpenWebNetCommandSession))
         {
-            for (var index = 0; index < gateway.Options.MaximumConcurrentCommandSessions; index++)
+            for (var index = 0; index < options.MaximumConcurrentCommandSessions; index++)
             {
-                tasks.Add(CreateAdHocSessionWorkerAsync(gateway, OpenNettySessionType.Command,
-                    gateway.Options.CommandSessionMaximumLifetime, cancellationToken));
+                tasks.Add(CreateAdHocSessionWorkerAsync(OpenNettySessionType.Command, cancellationToken));
             }
         }
 
@@ -64,7 +64,7 @@ public sealed class OpenNettyWorker : IOpenNettyWorker
 
         return Task.WhenAll(tasks);
 
-        async Task CreateSharedSessionWorkerAsync(OpenNettyGateway gateway, OpenNettySessionType type, CancellationToken cancellationToken)
+        async Task CreateSharedSessionWorkerAsync(OpenNettySessionType type, CancellationToken cancellationToken)
         {
             var context = ResilienceContextPool.Shared.Get(cancellationToken);
             context.Properties.Set(new ResiliencePropertyKey<OpenNettyGateway>(nameof(OpenNettyGateway)), gateway);
@@ -73,10 +73,10 @@ public sealed class OpenNettyWorker : IOpenNettyWorker
 
             _logger.LogInformation(6006, SR.GetResourceString(SR.ID6006), gateway, type);
 
-            await gateway.Options.SessionResiliencePipeline.ExecuteAsync(async context =>
+            await gateway.Options.DefaultSessionOptions.SessionResiliencePipeline.ExecuteAsync(async context =>
             {
                 using var source = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
-                await using var session = await OpenNettySession.CreateAsync(gateway, type, source.Token);
+                await using var session = await OpenNettySession.CreateAsync(gateway, type, null, source.Token);
 
                 _logger.LogDebug(6007, SR.GetResourceString(SR.ID6007), type, gateway, session);
 
@@ -131,8 +131,7 @@ public sealed class OpenNettyWorker : IOpenNettyWorker
             }, context);
         }
 
-        async Task CreateAdHocSessionWorkerAsync(
-            OpenNettyGateway gateway, OpenNettySessionType type, TimeSpan timeout, CancellationToken cancellationToken)
+        async Task CreateAdHocSessionWorkerAsync(OpenNettySessionType type, CancellationToken cancellationToken)
         {
             var context = ResilienceContextPool.Shared.Get(cancellationToken);
             context.Properties.Set(new ResiliencePropertyKey<OpenNettyGateway>(nameof(OpenNettyGateway)), gateway);
@@ -141,7 +140,7 @@ public sealed class OpenNettyWorker : IOpenNettyWorker
 
             _logger.LogInformation(6006, SR.GetResourceString(SR.ID6006), gateway, type);
 
-            await gateway.Options.SessionResiliencePipeline.ExecuteAsync(async context =>
+            await gateway.Options.DefaultSessionOptions.SessionResiliencePipeline.ExecuteAsync(async context =>
             {
                 // Wait until a new notification is ready to be processed.
                 while (await reader.WaitToReadAsync(context.CancellationToken))
@@ -153,7 +152,7 @@ public sealed class OpenNettyWorker : IOpenNettyWorker
                     }
 
                     using var source = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
-                    await using var session = await OpenNettySession.CreateAsync(gateway, type, source.Token);
+                    await using var session = await OpenNettySession.CreateAsync(gateway, type, null, source.Token);
 
                     _logger.LogDebug(6007, SR.GetResourceString(SR.ID6007), type, gateway, session);
 
@@ -207,7 +206,7 @@ public sealed class OpenNettyWorker : IOpenNettyWorker
 
                         // If an additional message is ready to be sent, re-use the current session
                         // to send it. Otherwise, stop iterating so that the session can be closed.
-                        while (reader.TryRead(out notification) || stopwatch.Elapsed < timeout);
+                        while (reader.TryRead(out notification) || stopwatch.Elapsed < options.CommandSessionMaximumLifetime);
 
                         _logger.LogDebug(6008, SR.GetResourceString(SR.ID6008), session);
                     }

--- a/src/OpenNetty/OpenNettyWorkerOptions.cs
+++ b/src/OpenNetty/OpenNettyWorkerOptions.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/opennetty/opennetty-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+namespace OpenNetty;
+
+/// <summary>
+/// Provides various settings used by workers to manage sessions and dispatch messages.
+/// </summary>
+public sealed record class OpenNettyWorkerOptions
+{
+    /// <summary>
+    /// Gets or sets the maximum lifetime of command sessions.
+    /// </summary>
+    public required TimeSpan CommandSessionMaximumLifetime { get; init; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent command sessions allowed.
+    /// </summary>
+    public required byte MaximumConcurrentCommandSessions { get; init; }
+
+    /// <summary>
+    /// Creates a default instance of the <see cref="OpenNettyWorkerOptions"/>
+    /// class with default options appropriate for the specified device.
+    /// </summary>
+    /// <param name="device">The device.</param>
+    /// <returns>A default instance of the <see cref="OpenNettyWorkerOptions"/> class.</returns>
+    public static OpenNettyWorkerOptions CreateDefaults(OpenNettyDevice device)
+    {
+        ArgumentNullException.ThrowIfNull(device);
+
+        return new()
+        {
+            CommandSessionMaximumLifetime    = device.Definition.Protocol is OpenNettyProtocol.Scs ? TimeSpan.FromSeconds(20) : TimeSpan.Zero,
+            MaximumConcurrentCommandSessions = device.Definition.Protocol is OpenNettyProtocol.Scs ? (byte) 3 : (byte) 0,
+        };
+    }
+}


### PR DESCRIPTION
Note: this PR also removes the automatic Zigbee supervision mode support from `OpenNettySession`: users are now encouraged to enable it via MQTT, using the dedicated commands under the Zigbee gateway.