### PR TITLE
Add support for Zigbee short pressure scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The following Legrand and BTicino products are partially or fully supported by O
 | MyHome Up         | Céliane            | 67561             |                   | 2-channel lighting/automation actuator |
 |                   |                    |                   |                   |                                        |
 | MyHome Play       | Céliane            | 67223             |                   | Light control switch                   |
+| MyHome Play       | Céliane            | 67266             |                   | Multifunction scenario switch          |
 | MyHome Play       |                    | 88328             | 3578              | Zigbee/USB gateway                     |
 | MyHome Play       |                    | 88337             |                   | Switched outlet                        |
 

--- a/src/OpenNetty.Mqtt/OpenNettyMqttHostedService.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttHostedService.cs
@@ -247,6 +247,21 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .Retry()
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
+            await _events.ShortPressureScenarioReported
+                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
+                .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
+                {
+                    var node = new JsonObject
+                    {
+                        ["event_type"] = "short_pressure"
+                    };
+
+                    builder.WithContentType(MediaTypeNames.Application.Json);
+                    builder.WithPayload(node.ToJsonString());
+                }))
+                .Retry()
+                .SubscribeAsync(static arguments => ValueTask.CompletedTask),
+
             await _events.ShutterDownScenarioReported
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>

--- a/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
@@ -716,6 +716,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     endpoint.HasCapability(OpenNettyCapabilities.DimmingScenarioState) ||
                     endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioState) ||
                     endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenarioState) ||
+                    endpoint.HasCapability(OpenNettyCapabilities.ShortPressureScenarioState) ||
                     endpoint.HasCapability(OpenNettyCapabilities.StopActionScenarioState) ||
                     endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioState) ||
                     endpoint.HasCapability(OpenNettyCapabilities.TimedScenarioState) ||
@@ -743,6 +744,11 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     if (endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenarioState))
                     {
                         types.Add("progressive_action");
+                    }
+
+                    if (endpoint.HasCapability(OpenNettyCapabilities.ShortPressureScenarioState))
+                    {
+                        types.Add("short_pressure");
                     }
 
                     if (endpoint.HasCapability(OpenNettyCapabilities.StopActionScenarioState))
@@ -782,6 +788,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                                                    endpoint.HasCapability(OpenNettyCapabilities.DimmingScenarioState) ||
                                                    endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioState) ||
                                                    endpoint.HasCapability(OpenNettyCapabilities.ProgressiveScenarioState) ||
+                                                   endpoint.HasCapability(OpenNettyCapabilities.ShortPressureScenarioState) ||
                                                    endpoint.HasCapability(OpenNettyCapabilities.StopActionScenarioState) ||
                                                    endpoint.HasCapability(OpenNettyCapabilities.StopUpDownScenarioState) ||
                                                    endpoint.HasCapability(OpenNettyCapabilities.TimedScenarioState) ||
@@ -1769,39 +1776,17 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 return $"{name} [{description}]";
             }
 
-            if (endpoint.Address is OpenNettyAddress address)
+            if (endpoint.Unit is not null)
             {
-                return $"{name} [{address.Type switch
-                {
-                    OpenNettyAddressType.Nitoo
-                        when OpenNettyAddress.ToNitooAddress(address) is { Identifier: uint identifier, Unit: byte unit }
-                        => $"D={identifier.ToString(CultureInfo.InvariantCulture)}/U={unit.ToString(CultureInfo.InvariantCulture)}",
-
-                    OpenNettyAddressType.ScsLightPoint when OpenNettyAddress.IsScsLightPointAreaAddress(address) &&
-                        OpenNettyAddress.ToScsLightPointAddress(address) is { Extension: byte extension, Area: byte area }
-                        => $"A={area.ToString(CultureInfo.InvariantCulture)}/I={extension.ToString(CultureInfo.InvariantCulture)}",
-
-                    OpenNettyAddressType.ScsLightPoint when OpenNettyAddress.IsScsLightPointGeneralAddress(address) &&
-                        OpenNettyAddress.ToScsLightPointAddress(address) is { Extension: byte extension }
-                        => $"GEN/I={extension.ToString(CultureInfo.InvariantCulture)}",
-
-                    OpenNettyAddressType.ScsLightPoint when OpenNettyAddress.IsScsLightPointGroupAddress(address) &&
-                        OpenNettyAddress.ToScsLightPointAddress(address) is { Extension: byte extension, Group: byte group }
-                        => $"GR={group.ToString(CultureInfo.InvariantCulture)}/I={extension.ToString(CultureInfo.InvariantCulture)}",
-
-                    OpenNettyAddressType.ScsLightPoint when OpenNettyAddress.IsScsLightPointPointToPointAddress(address) &&
-                        OpenNettyAddress.ToScsLightPointAddress(address) is { Extension: byte extension, Area: byte area, Point: byte point }
-                        => $"PL={point.ToString(CultureInfo.InvariantCulture)}/A={area.ToString(CultureInfo.InvariantCulture)}/I={extension.ToString(CultureInfo.InvariantCulture)}",
-
-                    OpenNettyAddressType.Zigbee
-                        when OpenNettyAddress.ToZigbeeAddress(address) is { Identifier: uint identifier, Unit: byte unit }
-                        => $"D={identifier.ToString(CultureInfo.InvariantCulture)}/U={unit.ToString(CultureInfo.InvariantCulture)}",
-
-                    _ => string.Empty
-                }}]";
+                return $"{name} [{endpoint.Unit.Definition.Description}]";
             }
 
-            return $"{name} [Local gateway]";
+            if (endpoint.Address is null)
+            {
+                return $"{name} [Local gateway]";
+            }
+
+            return name;
         }
 
         static bool SupportsCoverEntity(OpenNettyEndpoint endpoint)

--- a/src/OpenNetty/OpenNettyCapabilities.cs
+++ b/src/OpenNetty/OpenNettyCapabilities.cs
@@ -167,6 +167,11 @@ public static class OpenNettyCapabilities
     public static readonly OpenNettyCapability ProgressiveScenarioState = new("Progressive scenario state");
 
     /// <summary>
+    /// Short pressure scenario state.
+    /// </summary>
+    public static readonly OpenNettyCapability ShortPressureScenarioState = new("Short pressure scenario state");
+
+    /// <summary>
     /// Smart meter indexes.
     /// </summary>
     public static readonly OpenNettyCapability SmartMeterIndexes = new("Smart meter indexes");

--- a/src/OpenNetty/OpenNettyCoordinator.cs
+++ b/src/OpenNetty/OpenNettyCoordinator.cs
@@ -497,29 +497,6 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                     break;
                 }
 
-                case (OpenNettyNotifications.MessageReceived,
-                      OpenNettyMessage { Protocol: OpenNettyProtocol.Zigbee,
-                                         Type    : OpenNettyMessageType.BusCommand,
-                                         Command : OpenNettyCommand command,
-                                         Address : OpenNettyAddress address })
-                    when command == OpenNettyCommands.Lighting.Toggle:
-                {
-                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
-                    {
-                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
-                        if (endpoint.Gateway != notification.Gateway)
-                        {
-                            return;
-                        }
-
-                        if (endpoint.HasCapability(OpenNettyCapabilities.ToggleScenarioState))
-                        {
-                            await _events.PublishAsync(new ToggleScenarioReportedEventArgs(endpoint), cancellationToken);
-                        }
-                    });
-                    break;
-                }
-
                 // The shutter state and the position of an endpoint can be inferred from 3 types of messages:
                 //
                 //   - From an incoming or outgoing "STOP", "UP" or "DOWN" BUS COMMAND message:
@@ -1341,6 +1318,52 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                             }
 
                             await _events.PublishAsync(new DimmingStepReportedEventArgs(endpoint, step), cancellationToken);
+                        }
+                    });
+                    break;
+                }
+
+                case (OpenNettyNotifications.MessageReceived,
+                      OpenNettyMessage { Protocol: OpenNettyProtocol.Zigbee,
+                                         Type    : OpenNettyMessageType.BusCommand,
+                                         Command : OpenNettyCommand command,
+                                         Address : OpenNettyAddress address })
+                    when command == OpenNettyCommands.Lighting.Toggle:
+                {
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
+                    {
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
+                        {
+                            return;
+                        }
+
+                        if (endpoint.HasCapability(OpenNettyCapabilities.ToggleScenarioState))
+                        {
+                            await _events.PublishAsync(new ToggleScenarioReportedEventArgs(endpoint), cancellationToken);
+                        }
+                    });
+                    break;
+                }
+
+                case (OpenNettyNotifications.MessageReceived,
+                      OpenNettyMessage { Protocol: OpenNettyProtocol.Zigbee,
+                                         Type    : OpenNettyMessageType.BusCommand,
+                                         Command : OpenNettyCommand command,
+                                         Address : OpenNettyAddress address })
+                    when command == OpenNettyCommands.Scenario.ShortPressure:
+                {
+                    await Parallel.ForEachAsync(_manager.FindEndpointsByAddressAsync(message.Address.Value), async (endpoint, cancellationToken) =>
+                    {
+                        // Ignore the message if it was received by a different gateway than the one associated with the endpoint.
+                        if (endpoint.Gateway != notification.Gateway)
+                        {
+                            return;
+                        }
+
+                        if (endpoint.HasCapability(OpenNettyCapabilities.ShortPressureScenarioState))
+                        {
+                            await _events.PublishAsync(new ShortPressureScenarioReportedEventArgs(endpoint), cancellationToken);
                         }
                     });
                     break;

--- a/src/OpenNetty/OpenNettyDevices.xml
+++ b/src/OpenNetty/OpenNettyDevices.xml
@@ -952,6 +952,54 @@
   </Device>
 
   <Device Series="MyHome Play" Protocol="Zigbee" Medium="Radio">
+    <Identity Brand="Legrand" Collection="Céliane" Model="67266" Description="Multifunction scenario switch" />
+
+    <Capability Name="Battery level" />
+    <Capability Name="Firmware version" />
+    <Capability Name="Hardware version" />
+
+    <Unit Id="1" Description="Multifunction scenario 1">
+      <Capability Name="Short pressure scenario state" />
+      <Capability Name="Zigbee binding" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 1" />
+    </Unit>
+
+    <Unit Id="2" Description="Multifunction scenario 2">
+      <Capability Name="Short pressure scenario state" />
+      <Capability Name="Zigbee binding" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 2" />
+    </Unit>
+
+    <!-- Note: the physical switch labelled "4" is bound to unit 3 -->
+
+    <Unit Id="3" Description="Multifunction scenario 4">
+      <Capability Name="Short pressure scenario state" />
+      <Capability Name="Zigbee binding" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 4" />
+    </Unit>
+
+    <!-- Note: the physical switch labelled "3" is bound to unit 4 -->
+
+    <Unit Id="4" Description="Multifunction scenario 3">
+      <Capability Name="Short pressure scenario state" />
+      <Capability Name="Zigbee binding" />
+
+      <Setting Name="Home Assistant scenario device class" Value="button" />
+      <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
+      <Setting Name="Home Assistant scenario name" Value="Button 3" />
+    </Unit>
+  </Device>
+
+  <Device Series="MyHome Play" Protocol="Zigbee" Medium="Radio">
     <Identity Brand="BTicino" Model="3578"  Description="Zigbee/USB gateway" />
     <Identity Brand="Legrand" Model="88328" Description="Zigbee/USB gateway" />
 

--- a/src/OpenNetty/OpenNettyEvents.cs
+++ b/src/OpenNetty/OpenNettyEvents.cs
@@ -155,6 +155,12 @@ public sealed class OpenNettyEvents : IDisposable
         => _observable.OfType<EventArgs, ProgressiveScenarioReportedEventArgs>();
 
     /// <summary>
+    /// Gets an event triggered when a short pressure scenario is reported.
+    /// </summary>
+    public IAsyncObservable<ShortPressureScenarioReportedEventArgs> ShortPressureScenarioReported
+        => _observable.OfType<EventArgs, ShortPressureScenarioReportedEventArgs>();
+
+    /// <summary>
     /// Gets an event triggered when a shutter position is reported.
     /// </summary>
     public IAsyncObservable<ShutterPositionReportedEventArgs> ShutterPositionReported
@@ -165,24 +171,6 @@ public sealed class OpenNettyEvents : IDisposable
     /// </summary>
     public IAsyncObservable<ShutterStateReportedEventArgs> ShutterStateReported
         => _observable.OfType<EventArgs, ShutterStateReportedEventArgs>();
-
-    /// <summary>
-    /// Gets an event triggered when smart meter indexes are reported.
-    /// </summary>
-    public IAsyncObservable<SmartMeterIndexesReportedEventArgs> SmartMeterIndexesReported
-        => _observable.OfType<EventArgs, SmartMeterIndexesReportedEventArgs>();
-
-    /// <summary>
-    /// Gets an event triggered when a smart meter power cut mode is reported.
-    /// </summary>
-    public IAsyncObservable<SmartMeterPowerCutModeReportedEventArgs> SmartMeterPowerCutModeReported
-        => _observable.OfType<EventArgs, SmartMeterPowerCutModeReportedEventArgs>();
-
-    /// <summary>
-    /// Gets an event triggered when a smart meter rate type is reported.
-    /// </summary>
-    public IAsyncObservable<SmartMeterRateTypeReportedEventArgs> SmartMeterRateTypeReported
-        => _observable.OfType<EventArgs, SmartMeterRateTypeReportedEventArgs>();
 
     /// <summary>
     /// Gets an event triggered when a shutter DOWN scenario is reported.
@@ -201,6 +189,24 @@ public sealed class OpenNettyEvents : IDisposable
     /// </summary>
     public IAsyncObservable<ShutterUpScenarioReportedEventArgs> ShutterUpScenarioReported
         => _observable.OfType<EventArgs, ShutterUpScenarioReportedEventArgs>();
+
+    /// <summary>
+    /// Gets an event triggered when smart meter indexes are reported.
+    /// </summary>
+    public IAsyncObservable<SmartMeterIndexesReportedEventArgs> SmartMeterIndexesReported
+        => _observable.OfType<EventArgs, SmartMeterIndexesReportedEventArgs>();
+
+    /// <summary>
+    /// Gets an event triggered when a smart meter power cut mode is reported.
+    /// </summary>
+    public IAsyncObservable<SmartMeterPowerCutModeReportedEventArgs> SmartMeterPowerCutModeReported
+        => _observable.OfType<EventArgs, SmartMeterPowerCutModeReportedEventArgs>();
+
+    /// <summary>
+    /// Gets an event triggered when a smart meter rate type is reported.
+    /// </summary>
+    public IAsyncObservable<SmartMeterRateTypeReportedEventArgs> SmartMeterRateTypeReported
+        => _observable.OfType<EventArgs, SmartMeterRateTypeReportedEventArgs>();
 
     /// <summary>
     /// Gets an event triggered when a switch state is reported.
@@ -373,6 +379,12 @@ public sealed class OpenNettyEvents : IDisposable
     public sealed record class ProgressiveScenarioReportedEventArgs(OpenNettyEndpoint Endpoint, TimeSpan Duration) : EventArgs(Endpoint);
 
     /// <summary>
+    /// Represents event arguments used when a short pressure scenario is reported.
+    /// </summary>
+    /// <param name="Endpoint">The endpoint.</param>
+    public sealed record class ShortPressureScenarioReportedEventArgs(OpenNettyEndpoint Endpoint) : EventArgs(Endpoint);
+
+    /// <summary>
     /// Represents event arguments used when a shutter position is reported.
     /// </summary>
     /// <param name="Endpoint">The endpoint.</param>
@@ -386,6 +398,24 @@ public sealed class OpenNettyEvents : IDisposable
     /// <param name="State">The shutter state.</param>
     public sealed record class ShutterStateReportedEventArgs(OpenNettyEndpoint Endpoint,
         OpenNettyModels.Automation.ShutterState State) : EventArgs(Endpoint);
+
+    /// <summary>
+    /// Represents event arguments used when a shutter DOWN scenario is reported.
+    /// </summary>
+    /// <param name="Endpoint">The endpoint.</param>
+    public sealed record class ShutterDownScenarioReportedEventArgs(OpenNettyEndpoint Endpoint) : EventArgs(Endpoint);
+
+    /// <summary>
+    /// Represents event arguments used when a shutter STOP scenario is reported.
+    /// </summary>
+    /// <param name="Endpoint">The endpoint.</param>
+    public sealed record class ShutterStopScenarioReportedEventArgs(OpenNettyEndpoint Endpoint) : EventArgs(Endpoint);
+
+    /// <summary>
+    /// Represents event arguments used when a shutter UP scenario is reported.
+    /// </summary>
+    /// <param name="Endpoint">The endpoint.</param>
+    public sealed record class ShutterUpScenarioReportedEventArgs(OpenNettyEndpoint Endpoint) : EventArgs(Endpoint);
 
     /// <summary>
     /// Represents event arguments used when smart meter indexes are reported.
@@ -417,24 +447,6 @@ public sealed class OpenNettyEvents : IDisposable
     /// <param name="State">The switch state.</param>
     public sealed record class SwitchStateReportedEventArgs(OpenNettyEndpoint Endpoint,
         OpenNettyModels.Lighting.SwitchState State) : EventArgs(Endpoint);
-
-    /// <summary>
-    /// Represents event arguments used when a shutter DOWN scenario is reported.
-    /// </summary>
-    /// <param name="Endpoint">The endpoint.</param>
-    public sealed record class ShutterDownScenarioReportedEventArgs(OpenNettyEndpoint Endpoint) : EventArgs(Endpoint);
-
-    /// <summary>
-    /// Represents event arguments used when a shutter STOP scenario is reported.
-    /// </summary>
-    /// <param name="Endpoint">The endpoint.</param>
-    public sealed record class ShutterStopScenarioReportedEventArgs(OpenNettyEndpoint Endpoint) : EventArgs(Endpoint);
-
-    /// <summary>
-    /// Represents event arguments used when a shutter UP scenario is reported.
-    /// </summary>
-    /// <param name="Endpoint">The endpoint.</param>
-    public sealed record class ShutterUpScenarioReportedEventArgs(OpenNettyEndpoint Endpoint) : EventArgs(Endpoint);
 
     /// <summary>
     /// Represents event arguments used when a timed scenario is reported.


### PR DESCRIPTION
Note: short pressure scenarios are also supported by MyHome/SCS products but such products use very specific addresses that are not added in this PR.