### PR TITLE
Disable the "leave Zigbee network" button by default

### DIFF
--- a/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
@@ -2484,7 +2484,8 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                                 .Where(endpoint => endpoint.HasCapability(OpenNettyCapabilities.ZigbeeNetworkManagement))
                                 .CountAsync(cancellationToken)),
                         ["command_topic"] = $"{options.RootTopic}/{topic}/{OpenNettyMqttAttributes.ZigbeeNetwork}/set",
-                        ["payload_press"] = "leave"
+                        ["payload_press"] = "leave",
+                        ["enabled_by_default"] = false
                     });
 
                     AddComponent(components, new JsonObject


### PR DESCRIPTION
Leaving the Zigbee network is a dangerous action (specially if you're away from home and don't have a second OpenWebNet Zigbee gateway to re-open the network) so it's likely better to disable it by default.