### PR TITLE
Introduce a new flag to allow keeping a session alive even if no acknowledgment frame is received

### DIFF
--- a/src/OpenNetty/OpenNettyController.cs
+++ b/src/OpenNetty/OpenNettyController.cs
@@ -333,9 +333,9 @@ public class OpenNettyController
         // acknowledgment frame after the operation is complete. To ensure the gateway is
         // given enough time to create the network, the timeouts are increased if necessary.
         var options = GetTransmissionOptions(endpoint);
-        if (options.FrameAcknowledgementTimeout < TimeSpan.FromSeconds(20))
+        if (options.AcknowledgementTimeout < TimeSpan.FromSeconds(20))
         {
-            options = options with { FrameAcknowledgementTimeout = TimeSpan.FromSeconds(20) };
+            options = options with { AcknowledgementTimeout = TimeSpan.FromSeconds(20) };
         }
 
         if (options.OutgoingMessageProcessingTimeout < TimeSpan.FromSeconds(30))
@@ -1309,27 +1309,33 @@ public class OpenNettyController
             return description.Version;
         }
 
-        // Note: retrieving the firmware version of a battery-powered Zigbee endpoint
-        // can take a while. To ensure the operation is not aborted before the endpoint
-        // has a chance to respond, the timeouts are manually increased here.
         var options = GetTransmissionOptions(endpoint);
 
+        // Note: retrieving the firmware version of a battery-powered Zigbee endpoint can take
+        // a while: in this case, the acknowledgment frame is never returned immediately (and
+        // may not be returned at all if the end device doesn't reply). To ensure the operation
+        // is not aborted before the device has a chance to wake up and reply, the timeouts are
+        // slightly increased but missing acknowledgment frames are explicitly ignored to ensure
+        // the session will not be discarded by the worker if no acknowledgment frame is returned.
         if (endpoint.Address is not null && endpoint.HasCapability(OpenNettyCapabilities.ZigbeeEndDevice))
         {
-            if (options.FrameAcknowledgementTimeout < TimeSpan.FromSeconds(45))
+            options = options with
             {
-                options = options with { FrameAcknowledgementTimeout = TimeSpan.FromSeconds(45) };
-            }
+                DisallowAllRetransmissions = true,
+                KeepSessionAliveOnMissingAcknowledgement = true,
 
-            if (options.OutgoingMessageProcessingTimeout < TimeSpan.FromSeconds(45))
-            {
-                options = options with { OutgoingMessageProcessingTimeout = TimeSpan.FromSeconds(45) };
-            }
+                AcknowledgementTimeout = options.AcknowledgementTimeout < TimeSpan.FromSeconds(10)
+                    ? TimeSpan.FromSeconds(10)
+                    : options.AcknowledgementTimeout,
 
-            if (options.UniqueDimensionReplyTimeout < TimeSpan.FromSeconds(45))
-            {
-                options = options with { UniqueDimensionReplyTimeout = TimeSpan.FromSeconds(45) };
-            }
+                OutgoingMessageProcessingTimeout = options.OutgoingMessageProcessingTimeout < TimeSpan.FromSeconds(20)
+                    ? TimeSpan.FromSeconds(20)
+                    : options.OutgoingMessageProcessingTimeout,
+
+                UniqueDimensionReplyTimeout = options.UniqueDimensionReplyTimeout < TimeSpan.FromSeconds(10)
+                    ? TimeSpan.FromSeconds(10)
+                    : options.UniqueDimensionReplyTimeout
+            };
         }
 
         var values = await _service.GetDimensionAsync(
@@ -1368,27 +1374,33 @@ public class OpenNettyController
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0069));
         }
 
-        // Note: retrieving the hardware version of a battery-powered Zigbee endpoint
-        // can take a while. To ensure the operation is not aborted before the endpoint
-        // has a chance to respond, the timeouts are manually increased here.
         var options = GetTransmissionOptions(endpoint);
 
+        // Note: retrieving the hardware version of a battery-powered Zigbee endpoint can take
+        // a while: in this case, the acknowledgment frame is never returned immediately (and
+        // may not be returned at all if the end device doesn't reply). To ensure the operation
+        // is not aborted before the device has a chance to wake up and reply, the timeouts are
+        // slightly increased but missing acknowledgment frames are explicitly ignored to ensure
+        // the session will not be discarded by the worker if no acknowledgment frame is returned.
         if (endpoint.Address is not null && endpoint.HasCapability(OpenNettyCapabilities.ZigbeeEndDevice))
         {
-            if (options.FrameAcknowledgementTimeout < TimeSpan.FromSeconds(45))
+            options = options with
             {
-                options = options with { FrameAcknowledgementTimeout = TimeSpan.FromSeconds(45) };
-            }
+                DisallowAllRetransmissions = true,
+                KeepSessionAliveOnMissingAcknowledgement = true,
 
-            if (options.OutgoingMessageProcessingTimeout < TimeSpan.FromSeconds(45))
-            {
-                options = options with { OutgoingMessageProcessingTimeout = TimeSpan.FromSeconds(45) };
-            }
+                AcknowledgementTimeout = options.AcknowledgementTimeout < TimeSpan.FromSeconds(10)
+                    ? TimeSpan.FromSeconds(10)
+                    : options.AcknowledgementTimeout,
 
-            if (options.UniqueDimensionReplyTimeout < TimeSpan.FromSeconds(45))
-            {
-                options = options with { UniqueDimensionReplyTimeout = TimeSpan.FromSeconds(45) };
-            }
+                OutgoingMessageProcessingTimeout = options.OutgoingMessageProcessingTimeout < TimeSpan.FromSeconds(20)
+                    ? TimeSpan.FromSeconds(20)
+                    : options.OutgoingMessageProcessingTimeout,
+
+                UniqueDimensionReplyTimeout = options.UniqueDimensionReplyTimeout < TimeSpan.FromSeconds(10)
+                    ? TimeSpan.FromSeconds(10)
+                    : options.UniqueDimensionReplyTimeout
+            };
         }
 
         var values = await _service.GetDimensionAsync(
@@ -2075,9 +2087,9 @@ public class OpenNettyController
         // acknowledgment frame after the operation is complete. To ensure the gateway is
         // given enough time to join the network, the timeouts are increased if necessary.
         var options = GetTransmissionOptions(endpoint);
-        if (options.FrameAcknowledgementTimeout < TimeSpan.FromSeconds(20))
+        if (options.AcknowledgementTimeout < TimeSpan.FromSeconds(20))
         {
-            options = options with { FrameAcknowledgementTimeout = TimeSpan.FromSeconds(20) };
+            options = options with { AcknowledgementTimeout = TimeSpan.FromSeconds(20) };
         }
 
         if (options.OutgoingMessageProcessingTimeout < TimeSpan.FromSeconds(30))
@@ -2117,9 +2129,9 @@ public class OpenNettyController
         // acknowledgment frame after the operation is complete. To ensure the gateway is
         // given enough time to leave the network, the timeouts are increased if necessary.
         var options = GetTransmissionOptions(endpoint);
-        if (options.FrameAcknowledgementTimeout < TimeSpan.FromSeconds(20))
+        if (options.AcknowledgementTimeout < TimeSpan.FromSeconds(20))
         {
-            options = options with { FrameAcknowledgementTimeout = TimeSpan.FromSeconds(20) };
+            options = options with { AcknowledgementTimeout = TimeSpan.FromSeconds(20) };
         }
 
         if (options.OutgoingMessageProcessingTimeout < TimeSpan.FromSeconds(30))

--- a/src/OpenNetty/OpenNettyResources.resx
+++ b/src/OpenNetty/OpenNettyResources.resx
@@ -607,7 +607,7 @@
     <value>An error occurred while processing an outgoing MQTT message for topic {Topic} (payload: {Payload}).</value>
   </data>
   <data name="ID6024" xml:space="preserve">
-    <value>An outgoing message is about to be sent by gateway {Gateway} using session {Session}: {Message}.</value>
+    <value>An outgoing message is being sent by gateway {Gateway} using session {Session}: {Message}.</value>
   </data>
   <data name="ID8000" xml:space="preserve">
     <value>Switch</value>

--- a/src/OpenNetty/OpenNettySession.cs
+++ b/src/OpenNetty/OpenNettySession.cs
@@ -197,7 +197,7 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
                         .FirstOrDefault(static message => message.Type is OpenNettyMessageType.Acknowledgement             or
                                                                           OpenNettyMessageType.BusyNegativeAcknowledgement or
                                                                           OpenNettyMessageType.NegativeAcknowledgement)
-                        .Timeout(options.FrameAcknowledgementTimeout, AsyncObservable.Return<OpenNettyMessage?>(null))
+                        .Timeout(options.AcknowledgementTimeout, AsyncObservable.Return<OpenNettyMessage?>(null))
                         .RunAsync(cancellationToken))
                     {
                         case null:
@@ -207,7 +207,7 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
                             // Wait for the NACK frame to be returned before throwing an exception.
                             throw await messages
                                 .FirstOrDefault(static message => message.Type is OpenNettyMessageType.NegativeAcknowledgement)
-                                .Timeout(options.FrameAcknowledgementTimeout, AsyncObservable.Return<OpenNettyMessage?>(null))
+                                .Timeout(options.AcknowledgementTimeout, AsyncObservable.Return<OpenNettyMessage?>(null))
                                 .RunAsync(cancellationToken) switch
                                 {
                                     null => new OpenNettyException(OpenNettyErrorCode.NoAcknowledgementReceived, SR.GetResourceString(SR.ID0012)),

--- a/src/OpenNetty/OpenNettyTransmissionOptions.cs
+++ b/src/OpenNetty/OpenNettyTransmissionOptions.cs
@@ -16,32 +16,44 @@ namespace OpenNetty;
 public sealed record OpenNettyTransmissionOptions
 {
     /// <summary>
+    /// Gets or sets the acknowledgement timeout.
+    /// </summary>
+    public required TimeSpan AcknowledgementTimeout { get; init; }
+
+    /// <summary>
     /// Gets or sets the action validation timeout (Nitoo only).
     /// </summary>
     public required TimeSpan ActionValidationTimeout { get; init; }
 
     /// <summary>
     /// Gets or sets a boolean indicating whether the message
-    /// can be replayed if an error occurs while sending it.
+    /// can be replayed if any error occurs while sending it.
+    /// </summary>
+    public required bool DisallowAllRetransmissions { get; init; }
+
+    /// <summary>
+    /// Gets or sets a boolean indicating whether the message can be replayed if an error
+    /// indicating that the message couldn't be sent to the gateway occurs while sending it.
     /// </summary>
     public required bool DisallowUnsafeRetransmissions { get; init; }
 
     /// <summary>
-    /// Gets or sets the frame acknowledgement timeout.
-    /// </summary>
-    public required TimeSpan FrameAcknowledgementTimeout { get; init; }
-
-    /// <summary>
-    /// Gets or sets a boolean indicating whether OpenNetty should
+    /// Gets or sets a boolean indicating whether OpenNetty should not
     /// wait for the gateway to return an ACK, BUSY NACK or NACK frame.
     /// </summary>
     public required bool IgnoreAcknowledgementValidation { get; init; }
 
     /// <summary>
-    /// Gets or sets a boolean indicating whether OpenNetty should wait for the
+    /// Gets or sets a boolean indicating whether OpenNetty should not wait for the
     /// end device to reply with a VALID ACTION or INVALID ACTION frame (Nitoo only).
     /// </summary>
     public required bool IgnoreActionValidation { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the session should remain active
+    /// even if no acknowledgement frame was received from the gateway.
+    /// </summary>
+    public required bool KeepSessionAliveOnMissingAcknowledgement { get; init; }
 
     /// <summary>
     /// Gets or sets the reply timeout used when multiple dimensions should be returned.
@@ -90,17 +102,19 @@ public sealed record OpenNettyTransmissionOptions
 
         return new()
         {
-            ActionValidationTimeout          = device.Definition.Protocol is OpenNettyProtocol.Nitoo ? TimeSpan.FromSeconds(2) : TimeSpan.Zero,
-            DisallowUnsafeRetransmissions    = false,
-            FrameAcknowledgementTimeout      = TimeSpan.FromSeconds(5),
-            IgnoreAcknowledgementValidation  = false,
-            IgnoreActionValidation           = false,
-            MultipleDimensionReplyTimeout    = device.Definition.Protocol is OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee ? TimeSpan.FromSeconds(10) : TimeSpan.Zero,
-            MultipleStatusReplyTimeout       = device.Definition.Protocol is OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee ? TimeSpan.FromSeconds(10) : TimeSpan.Zero,
-            OutgoingMessageProcessingTimeout = TimeSpan.FromSeconds(10),
-            PostSendingDelay                 = device.Definition.Protocol is OpenNettyProtocol.Nitoo ? TimeSpan.FromMilliseconds(150) : TimeSpan.Zero,
-            UniqueDimensionReplyTimeout      = TimeSpan.FromSeconds(2),
-            UniqueStatusReplyTimeout         = TimeSpan.FromSeconds(2),
+            AcknowledgementTimeout                   = TimeSpan.FromSeconds(5),
+            ActionValidationTimeout                  = device.Definition.Protocol is OpenNettyProtocol.Nitoo ? TimeSpan.FromSeconds(2) : TimeSpan.Zero,
+            DisallowAllRetransmissions               = false,
+            DisallowUnsafeRetransmissions            = false,
+            IgnoreAcknowledgementValidation          = false,
+            IgnoreActionValidation                   = false,
+            KeepSessionAliveOnMissingAcknowledgement = false,
+            MultipleDimensionReplyTimeout            = device.Definition.Protocol is OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee ? TimeSpan.FromSeconds(10) : TimeSpan.Zero,
+            MultipleStatusReplyTimeout               = device.Definition.Protocol is OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee ? TimeSpan.FromSeconds(10) : TimeSpan.Zero,
+            OutgoingMessageProcessingTimeout         = TimeSpan.FromSeconds(10),
+            PostSendingDelay                         = device.Definition.Protocol is OpenNettyProtocol.Nitoo ? TimeSpan.FromMilliseconds(150) : TimeSpan.Zero,
+            UniqueDimensionReplyTimeout              = TimeSpan.FromSeconds(2),
+            UniqueStatusReplyTimeout                 = TimeSpan.FromSeconds(2),
 
             OutgoingMessageResiliencePipeline = new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
             {
@@ -153,6 +167,10 @@ public sealed record OpenNettyTransmissionOptions
 
                     return ValueTask.FromResult(arguments.Outcome.Exception switch
                     {
+                        // Never retry sending the message if the sender explicitly specified that
+                        // all retransmissions (even safe ones) are disallowed for this message.
+                        _ when options.DisallowAllRetransmissions => false,
+
                         // Nitoo gateways are known for returning NACK frames when sending multiple messages
                         // in a row. In this case, always retry sending the message 3 times before giving up.
                         OpenNettyException { ErrorCode: OpenNettyErrorCode.InvalidFrame }

--- a/src/OpenNetty/OpenNettyWorker.cs
+++ b/src/OpenNetty/OpenNettyWorker.cs
@@ -323,8 +323,16 @@ public sealed class OpenNettyWorker : IOpenNettyWorker
                     Transaction = transaction
                 });
 
-                // Note: these exceptions may indicate the session is stale and are re-thrown to ensure it is discarded.
-                throw;
+                // Note: these exceptions may indicate that the session is stale. In this case, unless the service has
+                // explicitly requested to ignore missing acknowledgments (e.g because a gateway is known to return them
+                // inconsistently for specific commands), these exceptions are re-thrown to ensure the session is discarded.
+
+                if (!options.KeepSessionAliveOnMissingAcknowledgement)
+                {
+                    throw;
+                }
+
+                return;
             }
 
             catch (OpenNettyException exception) when (exception.ErrorCode is OpenNettyErrorCode.InvalidFrame)


### PR DESCRIPTION
When requesting the hardware/firmware version of a battery-powered Zigbee device, the acknowledgment frame might never be returned if the device doesn't wake up or doesn't send back a reply. In this case, OpenNetty considers the session is stale and immediately discards it. To avoid that, this PR introduces a new `KeepSessionAliveOnMissingAcknowledgement` flag to allow opting out this behavior for specific operations. It also introduces a new `DisallowAllRetransmissions` flag to disallow all retransmissions, even when the error causing them indicates the message wasn't sent at all.