### PR TITLE
Support the new "ring" event for doorbell scenarios

### DIFF
--- a/src/OpenNetty.Mqtt/OpenNettyMqttHostedService.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttHostedService.cs
@@ -63,22 +63,42 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
         [
             await _events.ActionScenarioReported
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
-                .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
+                .Do(async arguments =>
                 {
-                    var node = new JsonObject
+                    // Note: if the device class is "doorbell", a standard "ring" event is also sent for action scenarios.
+                    if (arguments.Type is OpenNettyModels.ScenariosPlus.ActionScenarioType.Action &&
+                        arguments.Endpoint.GetStringSetting(OpenNettySettings.HomeAssistantScenarioDeviceClass)
+                            is OpenNettySettings.HomeAssistantDeviceClasses.Events.Doorbell)
                     {
-                        ["event_type"] = arguments.Type switch
+                        await ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                         {
-                            OpenNettyModels.ScenariosPlus.ActionScenarioType.Action     => "action",
-                            OpenNettyModels.ScenariosPlus.ActionScenarioType.StopAction => "stop_action",
+                            var node = new JsonObject
+                            {
+                                ["event_type"] = "ring"
+                            };
 
-                            _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0068))
-                        }
-                    };
+                            builder.WithContentType(MediaTypeNames.Application.Json);
+                            builder.WithPayload(node.ToJsonString());
+                        });
+                    }
 
-                    builder.WithContentType(MediaTypeNames.Application.Json);
-                    builder.WithPayload(node.ToJsonString());
-                }))
+                    await ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
+                    {
+                        var node = new JsonObject
+                        {
+                            ["event_type"] = arguments.Type switch
+                            {
+                                OpenNettyModels.ScenariosPlus.ActionScenarioType.Action     => "action",
+                                OpenNettyModels.ScenariosPlus.ActionScenarioType.StopAction => "stop_action",
+
+                                _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0068))
+                            }
+                        };
+
+                        builder.WithContentType(MediaTypeNames.Application.Json);
+                        builder.WithPayload(node.ToJsonString());
+                    });
+                })
                 .Retry()
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
@@ -358,51 +378,95 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
 
             await _events.PressureScenarioReported
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
-                .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
+                .Do(async arguments =>
                 {
-                    var node = new JsonObject
+                    // Note: if the device class is "doorbell", a standard "ring" event is also sent for short pressure scenarios.
+                    if (arguments.Type is OpenNettyModels.Scenarios.PressureScenarioType.Pressure &&
+                        arguments.Endpoint.GetStringSetting(OpenNettySettings.HomeAssistantScenarioDeviceClass)
+                            is OpenNettySettings.HomeAssistantDeviceClasses.Events.Doorbell)
                     {
-                        ["event_type"] = arguments.Type switch
+                        await ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                         {
-                            OpenNettyModels.Scenarios.PressureScenarioType.Pressure                     => "pressure",
-                            OpenNettyModels.Scenarios.PressureScenarioType.ReleaseAfterShortPressure    => "release_after_short_pressure",
-                            OpenNettyModels.Scenarios.PressureScenarioType.ReleaseAfterExtendedPressure => "release_after_extended_pressure",
-                            OpenNettyModels.Scenarios.PressureScenarioType.ExtendedPressure             => "extended_pressure",
+                            var node = new JsonObject
+                            {
+                                ["event_type"] = "ring",
+                                ["scenario_type"] = "evolved",
+                                ["button"] = arguments.Button
+                            };
 
-                            _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0068))
-                        },
-                        ["scenario_type"] = "evolved",
-                        ["button"] = arguments.Button
-                    };
+                            builder.WithContentType(MediaTypeNames.Application.Json);
+                            builder.WithPayload(node.ToJsonString());
+                        });
+                    }
 
-                    builder.WithContentType(MediaTypeNames.Application.Json);
-                    builder.WithPayload(node.ToJsonString());
-                }))
+                    await ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
+                    {
+                        var node = new JsonObject
+                        {
+                            ["event_type"] = arguments.Type switch
+                            {
+                                OpenNettyModels.Scenarios.PressureScenarioType.Pressure                     => "pressure",
+                                OpenNettyModels.Scenarios.PressureScenarioType.ReleaseAfterShortPressure    => "release_after_short_pressure",
+                                OpenNettyModels.Scenarios.PressureScenarioType.ReleaseAfterExtendedPressure => "release_after_extended_pressure",
+                                OpenNettyModels.Scenarios.PressureScenarioType.ExtendedPressure             => "extended_pressure",
+
+                                _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0068))
+                            },
+                            ["scenario_type"] = "evolved",
+                            ["button"] = arguments.Button
+                        };
+
+                        builder.WithContentType(MediaTypeNames.Application.Json);
+                        builder.WithPayload(node.ToJsonString());
+                    });
+                })
                 .Retry()
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.PressureScenarioPlusReported
                 .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
-                .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
+                .Do(async arguments =>
                 {
-                    var node = new JsonObject
+                    // Note: if the device class is "doorbell", a standard "ring" event is also sent for short pressure scenarios.
+                    if (arguments.Type is OpenNettyModels.ScenariosPlus.PressureScenarioType.ShortPressure &&
+                        arguments.Endpoint.GetStringSetting(OpenNettySettings.HomeAssistantScenarioDeviceClass)
+                            is OpenNettySettings.HomeAssistantDeviceClasses.Events.Doorbell)
                     {
-                        ["event_type"] = arguments.Type switch
+                        await ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                         {
-                            OpenNettyModels.ScenariosPlus.PressureScenarioType.ShortPressure           => "short_pressure",
-                            OpenNettyModels.ScenariosPlus.PressureScenarioType.StartOfExtendedPressure => "start_of_extended_pressure",
-                            OpenNettyModels.ScenariosPlus.PressureScenarioType.ExtendedPressure        => "extended_pressure",
-                            OpenNettyModels.ScenariosPlus.PressureScenarioType.EndOfExtendedPressure   => "end_of_extended_pressure",
+                            var node = new JsonObject
+                            {
+                                ["event_type"] = "ring",
+                                ["scenario_type"] = "plus",
+                                ["button"] = arguments.Button
+                            };
 
-                            _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0068))
-                        },
-                        ["scenario_type"] = "plus",
-                        ["button"] = arguments.Button
-                    };
+                            builder.WithContentType(MediaTypeNames.Application.Json);
+                            builder.WithPayload(node.ToJsonString());
+                        });
+                    }
 
-                    builder.WithContentType(MediaTypeNames.Application.Json);
-                    builder.WithPayload(node.ToJsonString());
-                }))
+                    await ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
+                    {
+                        var node = new JsonObject
+                        {
+                            ["event_type"] = arguments.Type switch
+                            {
+                                OpenNettyModels.ScenariosPlus.PressureScenarioType.ShortPressure           => "short_pressure",
+                                OpenNettyModels.ScenariosPlus.PressureScenarioType.StartOfExtendedPressure => "start_of_extended_pressure",
+                                OpenNettyModels.ScenariosPlus.PressureScenarioType.ExtendedPressure        => "extended_pressure",
+                                OpenNettyModels.ScenariosPlus.PressureScenarioType.EndOfExtendedPressure   => "end_of_extended_pressure",
+
+                                _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0068))
+                            },
+                            ["scenario_type"] = "plus",
+                            ["button"] = arguments.Button
+                        };
+
+                        builder.WithContentType(MediaTypeNames.Application.Json);
+                        builder.WithPayload(node.ToJsonString());
+                    });
+                })
                 .Retry()
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 

--- a/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
@@ -865,7 +865,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     else if (platform is OpenNettySettings.HomeAssistantEntityTypes.Switch)
                     {
                         component["device_class"] = endpoint.GetStringSetting(OpenNettySettings.HomeAssistantSwitchDeviceClass)
-                            ?? OpenNettySettings.HomeAssistantDeviceClasses.Switch;
+                            ?? OpenNettySettings.HomeAssistantDeviceClasses.Switches.Switch;
                     }
 
                     components.Add(CreateEntityNode(component));
@@ -922,7 +922,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                         ["platform"] = "cover",
                         ["unique_id"] = ComputeEntityUniqueId(endpoint, "9b138d62-bb0d-49cb-8624-1d85f9e86a6e"u8),
                         ["device_class"] = endpoint.GetStringSetting(OpenNettySettings.HomeAssistantCoverDeviceClass)
-                            ?? OpenNettySettings.HomeAssistantDeviceClasses.Shutter,
+                            ?? OpenNettySettings.HomeAssistantDeviceClasses.Covers.Shutter,
                         ["name"] = endpoint.GetStringSetting(OpenNettySettings.HomeAssistantCoverName) ??
                             ComputeEntityName(
                                 name    : GetLocalizedString(SR.ID8004, culture),
@@ -1011,6 +1011,12 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
 
                     if (endpoint.HasCapability(OpenNettyCapabilities.ActionScenarioEvent))
                     {
+                        if (endpoint.GetStringSetting(OpenNettySettings.HomeAssistantScenarioDeviceClass)
+                            is OpenNettySettings.HomeAssistantDeviceClasses.Events.Doorbell)
+                        {
+                            types.Add("ring");
+                        }
+
                         types.Add("action");
                         types.Add("stop_action");
                     }
@@ -1028,6 +1034,12 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
 
                     if (endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioEvent))
                     {
+                        if (endpoint.GetStringSetting(OpenNettySettings.HomeAssistantScenarioDeviceClass)
+                            is OpenNettySettings.HomeAssistantDeviceClasses.Events.Doorbell)
+                        {
+                            types.Add("ring");
+                        }
+
                         types.Add("pressure");
                         types.Add("release_after_short_pressure");
                         types.Add("release_after_extended_pressure");
@@ -1036,6 +1048,12 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
 
                     if (endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioPlusEvent))
                     {
+                        if (endpoint.GetStringSetting(OpenNettySettings.HomeAssistantScenarioDeviceClass)
+                            is OpenNettySettings.HomeAssistantDeviceClasses.Events.Doorbell)
+                        {
+                            types.Add("ring");
+                        }
+
                         types.Add("short_pressure");
                         types.Add("start_of_extended_pressure");
                         types.Add("extended_pressure");

--- a/src/OpenNetty/OpenNettySettings.cs
+++ b/src/OpenNetty/OpenNettySettings.cs
@@ -228,14 +228,97 @@ public static class OpenNettySettings
     public static class HomeAssistantDeviceClasses
     {
         /// <summary>
-        /// Shutter.
+        /// Device classes for cover entities.
         /// </summary>
-        public const string Shutter = "shutter";
+        public static class Covers
+        {
+            /// <summary>
+            /// Awning.
+            /// </summary>
+            public const string Awning = "awning";
+
+            /// <summary>
+            /// Blind.
+            /// </summary>
+            public const string Blind = "blind";
+
+            /// <summary>
+            /// Curtain.
+            /// </summary>
+            public const string Curtain = "curtain";
+
+            /// <summary>
+            /// Damper.
+            /// </summary>
+            public const string Damper = "damper";
+
+            /// <summary>
+            /// Door.
+            /// </summary>
+            public const string Door = "door";
+
+            /// <summary>
+            /// Garage.
+            /// </summary>
+            public const string Garage = "garage";
+
+            /// <summary>
+            /// Gate.
+            /// </summary>
+            public const string Gate = "gate";
+
+            /// <summary>
+            /// Shade.
+            /// </summary>
+            public const string Shade = "shade";
+
+            /// <summary>
+            /// Shutter.
+            /// </summary>
+            public const string Shutter = "shutter";
+
+            /// <summary>
+            /// Window.
+            /// </summary>
+            public const string Window = "window";
+        }
 
         /// <summary>
-        /// Switch.
+        /// Device classes for event entities.
         /// </summary>
-        public const string Switch = "switch";
+        public static class Events
+        {
+            /// <summary>
+            /// Button.
+            /// </summary>
+            public const string Button = "button";
+
+            /// <summary>
+            /// Doorbell.
+            /// </summary>
+            public const string Doorbell = "doorbell";
+
+            /// <summary>
+            /// Motion.
+            /// </summary>
+            public const string Motion = "motion";
+        }
+
+        /// <summary>
+        /// Device classes for switch entities.
+        /// </summary>
+        public static class Switches
+        {
+            /// <summary>
+            /// Outlet.
+            /// </summary>
+            public const string Outlet = "outlet";
+
+            /// <summary>
+            /// Switch.
+            /// </summary>
+            public const string Switch = "switch";
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Recent versions of HA require that entities with the `doorbell` device class support the new `ring` event type. Since the Legrand 03648 SCS/Nitoo gateway exposes a doorbell scenario entity, we need to update OpenNetty to support `ring` before things stop working in HA 2027.4:

```
Entity event.entity_name is a doorbell event entity but does not support the 'ring' event type. This will stop working in Home Assistant 2027.4, please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mqtt%22
```