### PR TITLE
Change the name of the configuration file used by the daemon and allow overriding it via `IConfiguration`

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ sudo systemctl enable opennetty
 
 ### Create the configuration file
 
-The OpenNetty daemon relies on a configuration file to locate the OpenWebNet gateways and devices. For that, create
-a new XML file named `OpenNettyConfiguration.xml` locally with the following content and replace the
-server/port/username/password attributes to match the values used by your MQTT broker:
+The OpenNetty daemon relies on a configuration file to locate the OpenWebNet gateways and devices. For that,
+create a new XML file named `configuration.xml` (**make sure to respect the case**) with the following content
+and replace the server/port/username/password attributes to match the values used by your MQTT broker:
 
 ```xml
 <Configuration>
@@ -168,6 +168,11 @@ server/port/username/password attributes to match the values used by your MQTT b
 > 
 > </Configuration>
 > ```
+
+> [!TIP]
+> Instead of having a single configuration file, you can also split the configuration into multiple files
+> and store them under the `/usr/local/bin/opennetty/configuration` directory: OpenNetty will automatically
+> load all the `.xml` files present in this directory and merge their content together at runtime.
 
 ### If necessary, change the UI culture used in the MQTT discovery payloads
 
@@ -642,7 +647,7 @@ var builder = Host.CreateApplicationBuilder();
 
 builder.Services.AddOpenNetty(options =>
 {
-    var file = builder.Environment.ContentRootFileProvider.GetFileInfo("OpenNettyConfiguration.xml");
+    var file = builder.Environment.ContentRootFileProvider.GetFileInfo("configuration.xml");
     options.ImportFromXmlConfiguration(file);
 });
 
@@ -719,7 +724,7 @@ change MUST include one or more `<Scenario>` node(s) indicating the name of the 
 > 
 > builder.Services.AddOpenNetty(options =>
 > {
->     var file = builder.Environment.ContentRootFileProvider.GetFileInfo("OpenNettyConfiguration.xml");
+>     var file = builder.Environment.ContentRootFileProvider.GetFileInfo("configuration.xml");
 >     options.ImportFromXmlConfiguration(file);
 > });
 > 

--- a/src/OpenNetty.Daemon/Program.cs
+++ b/src/OpenNetty.Daemon/Program.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Immutable;
 using System.Reactive.Linq;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -22,22 +23,28 @@ builder.Services.AddSystemd();
 
 builder.Services.AddOpenNetty(options =>
 {
-    // Load the configuration files from the content root and the "Configuration" directory, if available.
-    ImmutableArray<IFileInfo> files = [.. GetConfigurationFiles(builder.Environment.ContentRootFileProvider)];
+    // Load the configuration files from the specified location(s).
+    ImmutableArray<IFileInfo> files = [.. GetConfigurationFiles(builder.Configuration, builder.Environment.ContentRootFileProvider)];
+    if (files.IsDefaultOrEmpty)
+    {
+        throw new InvalidOperationException(SR.FormatID0125(
+            builder.Configuration["ConfigurationFile"] ?? "configuration.xml", ".xml",
+            builder.Configuration["ConfigurationDirectory"] ?? "configuration"));
+    }
 
     options.ImportFromXmlConfiguration(files).ValidateOnStart();
 
     options.AddMqttIntegration(options => options.ImportFromXmlConfiguration(files).ValidateOnStart());
 
-    static IEnumerable<IFileInfo> GetConfigurationFiles(IFileProvider provider)
+    static IEnumerable<IFileInfo> GetConfigurationFiles(IConfiguration configuration, IFileProvider provider)
     {
-        var file = provider.GetFileInfo("OpenNettyConfiguration.xml");
+        var file = provider.GetFileInfo(configuration["ConfigurationFile"] ?? "configuration.xml");   
         if (file.Exists)
         {
             yield return file;
         }
 
-        var directory = provider.GetDirectoryContents("Configuration");
+        var directory = provider.GetDirectoryContents(configuration["ConfigurationDirectory"] ?? "configuration");
         if (directory.Exists)
         {
             using var enumerator = directory.OrderBy(static file => file.Name, StringComparer.Ordinal).GetEnumerator();

--- a/src/OpenNetty/OpenNettyConfiguration.cs
+++ b/src/OpenNetty/OpenNettyConfiguration.cs
@@ -109,6 +109,11 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
 
         var builder = new ValidateOptionsResultBuilder();
 
+        if (options.Gateways.Count is 0)
+        {
+            builder.AddError(SR.GetResourceString(SR.ID0126));
+        }
+
         if (options.Devices.GroupBy(static device => device.Identifier)
             .Where(static group => group.Count() is > 1)
             .Select(static group => group.Key)

--- a/src/OpenNetty/OpenNettyResources.resx
+++ b/src/OpenNetty/OpenNettyResources.resx
@@ -489,6 +489,12 @@
   <data name="ID0124" xml:space="preserve">
     <value>The specified collection contains null elements, which is not valid for this operation.</value>
   </data>
+  <data name="ID0125" xml:space="preserve">
+    <value>No configuration file was found. For the OpenNetty daemon to work correctly, a configuration file named '{0}' must be present in the application directory. Alternatively, one or more configuration files ending with '{1}' can be placed in the '{2}' directory.</value>
+  </data>
+  <data name="ID0126" xml:space="preserve">
+    <value>At least one OpenWebNet gateway must be configured.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The endpoint name '{0}' is not valid. Endpoint names cannot contain the '+' or '*' characters.</value>
   </data>


### PR DESCRIPTION
This PR changes the default name of the configuration file from `OpenNettyConfiguration.xml` to `configuration.xml` (to match the casing used for the daemon binary). It also ensures an exception is thrown if no configuration file can be located or if no gateway was configured in the options.