### PR TITLE
Introduce support for ID-less devices and revamp the device APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,30 +206,26 @@ socket to initiate OpenWebNet sessions:
 
   <!-- In One by Legrand gateway -->
 
-  <Device Brand="Legrand" Model="88213" SerialNumber="148366">
+  <Device Brand="Legrand" Model="88213">
     <Gateway Name="OPEN-Nitoo gateway" Type="Serial"
              Port="/dev/serial/by-id/usb-Btcino_Terraneo_Mod._SFERA_Tele_Loop-if00" />
   </Device>
 
   <!-- MyHome Play gateway -->
 
-  <Device Brand="Legrand" Model="88328" SerialNumber="0026BD26">
+  <Device Brand="Legrand" Model="88328">
     <Gateway Name="OPEN-Zigbee gateway" Type="Serial"
              Port="/dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0" />
   </Device>
 
   <!-- MyHome Up gateway -->
 
-  <Device Brand="BTicino" Model="F454" MacAddress="00:03:50:A2:27:1B">
+  <Device Brand="BTicino" Model="F454">
     <Gateway Name="OPEN-SCS gateway" Type="Tcp" Server="192.168.5.10" Password="aJhYiBHk8" />
   </Device>
 
 </Configuration>
 ```
-
-> [!TIP]
-> If you don't know the serial number of your MyHome Play gateway, you can temporarily specify a fake one and request the MAC
-> address via MQTT. For instance, if the EUI-64 MAC address is `00:04:74:00:00:26:BD:26`, its serial number will be `0026BD26`.
 
 > [!IMPORTANT]
 > OpenNetty natively supports both the legacy "OPEN authentication" method and the newer – and safer –
@@ -244,7 +240,7 @@ socket to initiate OpenWebNet sessions:
 To be able to communicate with "In One by Legrand", "MyHome Play" and "MyHome Up" devices, OpenNetty requires listing them in the configuration file.
 
 For that, you need to add a `Device` node with the correct brand/model attributes for each device present in the installation:
-  - The serial number (or MAC address for Ethernet gateways) is required for all devices.
+  - The serial number (or MAC address for Ethernet gateways) is optional but strongly recommended when possible to help identify devices in Home Assistant.
 
   - The unit node - also known as a "module" in MyHome Suite - is generally required for an endpoint, except when targeting a feature exposed by the device
   itself and not one of its units: in this case, the endpoint must appear directly under the `Device` node and not under a `Unit` node.
@@ -569,6 +565,8 @@ builder.Services.AddOpenNetty(options =>
 
     options.AddGateway(gateway);
 
+    var definition = OpenNettyDevices.GetDeviceDefinitionByModel(OpenNettyBrand.BTicino, "F418U2");
+
     options.AddEndpoint(new OpenNettyEndpoint
     {
         // SCS light point point-to-point address:
@@ -580,21 +578,15 @@ builder.Services.AddOpenNetty(options =>
             point    : 3),
         Device = new OpenNettyDevice
         {
-            Definition = OpenNettyDevices.GetDeviceByModel(OpenNettyBrand.BTicino, "F418U2")
-                ?? throw new InvalidOperationException("The specified product is not supported."),
-            Identity = new OpenNettyDeviceIdentity
-            {
-                Brand = OpenNettyBrand.BTicino,
-                Collection = null,
-                Description = "2-gang DIN rail dimmer switch",
-                Model = "F418U2"
-            }
+            Definition = definition,
+            Identifier = OpenNettyDeviceIdentifier.FromScsSerialNumber("00B582A5"),
+            Identity = definition.GetIdentity(OpenNettyBrand.BTicino, "F418U2"),
+            Name = "BTicino F418U2 (00B582A5)"
         },
         Gateway = gateway,
         Unit = new OpenNettyUnit
         {
-            Definition = OpenNettyDevices.GetUnitByModel(OpenNettyBrand.BTicino, "F418U2", 1)
-                ?? throw new InvalidOperationException("The specified product is not supported.")
+            Definition = definition.GetUnitDefinition(1)
         },
         Name = "Bathroom/Recessed light",
         Protocol = OpenNettyProtocol.Scs
@@ -785,20 +777,17 @@ Settings can be attached programmatically or via the configuration file to devic
 ```
 
 ```csharp
+var definition = OpenNettyDevices.GetDeviceDefinitionByModel(OpenNettyBrand.Legrand, "67222");
+
 options.AddEndpoint(new OpenNettyEndpoint
 {
     Address = OpenNettyAddress.FromNitooAddress(identifier: 487932, unit: 4),
     Device = new OpenNettyDevice
     {
-        Definition = OpenNettyDevices.GetDeviceByModel(OpenNettyBrand.Legrand, "67222")!,
+        Definition = definition,
         Identifier = OpenNettyDeviceIdentifier.FromNitooSerialNumber(487932),
-        Identity = new OpenNettyDeviceIdentity
-        {
-            Brand = OpenNettyBrand.Legrand,
-            Collection = "Céliane",
-            Description = "Dimmable switched outlet",
-            Model = "67222"
-        },
+        Identity = definition.GetIdentity(OpenNettyBrand.Legrand, "67222"),
+        Name = "Legrand 67222 (487932)",
         Settings = ImmutableDictionary.Create<OpenNettySetting, string>()
             .Add(OpenNettySettings.ActionValidation, bool.FalseString)
     },
@@ -807,7 +796,7 @@ options.AddEndpoint(new OpenNettyEndpoint
     Protocol = OpenNettyProtocol.Nitoo,
     Unit = new OpenNettyUnit
     {
-        Definition = OpenNettyDevices.GetUnitByModel(OpenNettyBrand.Legrand, "67222", 4)!
+        Definition = definition.GetUnitDefinition(4)
     }
 });
 ```

--- a/src/OpenNetty.Mqtt/OpenNettyMqttConfiguration.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttConfiguration.cs
@@ -45,15 +45,26 @@ public sealed class OpenNettyMqttConfiguration : IPostConfigureOptions<OpenNetty
 
         foreach (var endpoint in options.Endpoints)
         {
-            if (endpoint.GetStringSetting(OpenNettySettings.MqttTopic) is string topic &&
-                (topic.Contains('+', StringComparison.OrdinalIgnoreCase) ||
-                 topic.Contains('*', StringComparison.OrdinalIgnoreCase)))
+            switch (endpoint.GetStringSetting(OpenNettySettings.MqttTopic))
             {
-                builder.AddError(SR.FormatID2005(topic));
+                case string value when value.Contains('+', StringComparison.OrdinalIgnoreCase) ||
+                                       value.Contains('*', StringComparison.OrdinalIgnoreCase):
+                    builder.AddError(SR.FormatID2005(value));
+                    break;
+            }
+
+            switch (endpoint.GetStringSetting(OpenNettySettings.HomeAssistantObjectId))
+            {
+                case string value when !IsValidObjectIdentifier(value):
+                    builder.AddError(SR.FormatID2018(value));
+                    break;
             }
         }
 
         return builder.Build();
+
+        static bool IsValidObjectIdentifier(string identifier) => identifier.All(static character =>
+            char.IsAsciiLetterOrDigit(character) || character is '_' or '-');
     }
 
     /// <inheritdoc/>

--- a/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
@@ -801,7 +801,8 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     .Append('/')
                     .Append("opennetty-").Append(Enum.GetName(device.Definition.Protocol)!.ToLowerInvariant())
                     .Append('/')
-                    .Append([.. device.Identifier.ToString().Where(IsValidNodeIdCharacter)])
+                    .Append(device.GetStringSetting(OpenNettySettings.HomeAssistantObjectId)
+                        ?? SanitizeDiscoveryObjectId(device.Name))
                     .Append('/')
                     .Append("config")
                     .ToString())
@@ -856,7 +857,8 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     .Append('/')
                     .Append("opennetty-").Append(Enum.GetName(endpoint.Protocol)!.ToLowerInvariant())
                     .Append('/')
-                    .Append(ComputeVirtualDeviceUniqueId(endpoint))
+                    .Append(endpoint.GetStringSetting(OpenNettySettings.HomeAssistantObjectId)
+                        ?? SanitizeDiscoveryObjectId(endpoint.Name))
                     .Append('/')
                     .Append("config")
                     .ToString())
@@ -906,7 +908,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 {
                     ["platform"] = platform,
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "feb44223-4814-4652-933c-53dbbaabac3f"u8),
-                    ["name"] = name ?? ComputeEntityName(
+                    ["name"] = name ?? ComputeEntityDisplayName(
                         name    : platform is OpenNettySettings.HomeAssistantEntityTypes.Light ?
                             GetLocalizedString(SR.ID8001, culture) : GetLocalizedString(SR.ID8000, culture),
                         endpoint: endpoint,
@@ -971,7 +973,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                         ["platform"] = "button",
                         ["unique_id"] = ComputeEntityUniqueId(endpoint, "3a10d925-c599-41a9-8a7e-30a04aefec86"u8),
                         ["entity_category"] = "diagnostic",
-                        ["name"] = ComputeEntityName(
+                        ["name"] = ComputeEntityDisplayName(
                             name    : GetLocalizedString(SR.ID8002, culture),
                             endpoint: endpoint,
                             culture : culture,
@@ -991,7 +993,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                         ["platform"] = "button",
                         ["unique_id"] = ComputeEntityUniqueId(endpoint, "f05ecfb8-70d5-4116-b0a8-2f6d9d02090f"u8),
                         ["entity_category"] = "diagnostic",
-                        ["name"] = ComputeEntityName(
+                        ["name"] = ComputeEntityDisplayName(
                             name    : GetLocalizedString(SR.ID8003, culture),
                             endpoint: endpoint,
                             culture : culture,
@@ -1014,7 +1016,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["device_class"] = endpoint.GetStringSetting(OpenNettySettings.HomeAssistantCoverDeviceClass)
                         ?? OpenNettySettings.HomeAssistantDeviceClasses.Covers.Shutter,
                     ["name"] = endpoint.GetStringSetting(OpenNettySettings.HomeAssistantCoverName) ??
-                        ComputeEntityName(
+                        ComputeEntityDisplayName(
                             name    : GetLocalizedString(SR.ID8004, culture),
                             endpoint: endpoint,
                             culture : culture,
@@ -1048,7 +1050,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                         ["platform"] = "button",
                         ["unique_id"] = ComputeEntityUniqueId(endpoint, "3a760f9d-ca89-4c9e-9ad4-8ba40ad36f59"u8),
                         ["entity_category"] = "diagnostic",
-                        ["name"] = ComputeEntityName(
+                        ["name"] = ComputeEntityDisplayName(
                             name    : GetLocalizedString(SR.ID8005, culture),
                             endpoint: endpoint,
                             culture : culture,
@@ -1068,7 +1070,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                         ["platform"] = "button",
                         ["unique_id"] = ComputeEntityUniqueId(endpoint, "5731274c-e498-4c7b-8671-6de8c448eb99"u8),
                         ["entity_category"] = "diagnostic",
-                        ["name"] = ComputeEntityName(
+                        ["name"] = ComputeEntityDisplayName(
                             name    : GetLocalizedString(SR.ID8006, culture),
                             endpoint: endpoint,
                             culture : culture,
@@ -1171,7 +1173,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "event",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "7faeaa9a-ae51-43f4-af82-65d2e24e14d0"u8),
                     ["icon"] = endpoint.GetStringSetting(OpenNettySettings.HomeAssistantScenarioIcon) ?? "mdi:lightning-bolt",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8007, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1209,7 +1211,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 {
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "63485e4c-a3bd-4fc9-831d-b96bacddade9"u8),
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8008, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1223,7 +1225,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 {
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "bca953c0-7598-4baa-91df-f14ddc30450f"u8),
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8025, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1241,7 +1243,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 {
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "f47365e3-86fa-449f-b84e-a06acc3484b1"u8),
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8111, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1256,7 +1258,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 {
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "5c2db171-97b3-451e-a502-8800928b4335"u8),
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8112, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1274,7 +1276,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 {
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "f053a594-66fa-42a6-9237-64d570b2bd57"u8),
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8009, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1288,7 +1290,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 {
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "d292636e-00d3-442e-b1db-73d60b4085ec"u8),
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8010, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1307,7 +1309,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "9563390d-24c4-48f0-a0de-61fef1e58eca"u8),
                     ["entity_category"] = "diagnostic",
                     ["device_class"] = "timestamp",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8119, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1334,7 +1336,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                                 .. "be2887c3-f4ae-4935-bad6-1ffb1227d28b"u8,
                                 .. Encoding.UTF8.GetBytes(button.ToString(CultureInfo.InvariantCulture))
                             ]),
-                            ["name"] = ComputeEntityName(
+                            ["name"] = ComputeEntityDisplayName(
                                 name    : string.Format(GetLocalizedString(SR.ID8011, culture), button.ToString(CultureInfo.InvariantCulture)),
                                 endpoint: endpoint,
                                 culture : culture,
@@ -1352,7 +1354,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                                 .. "81e3f75a-fab3-4842-bb5e-1531d20290dd"u8,
                                 .. Encoding.UTF8.GetBytes(button.ToString(CultureInfo.InvariantCulture))
                             ]),
-                            ["name"] = ComputeEntityName(
+                            ["name"] = ComputeEntityDisplayName(
                                 name    : string.Format(GetLocalizedString(SR.ID8012, culture), button.ToString(CultureInfo.InvariantCulture)),
                                 endpoint: endpoint,
                                 culture : culture,
@@ -1370,7 +1372,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                                 .. "3f069e7f-7c8f-4730-b067-9a944f61700b"u8,
                                 .. Encoding.UTF8.GetBytes(button.ToString(CultureInfo.InvariantCulture))
                             ]),
-                            ["name"] = ComputeEntityName(
+                            ["name"] = ComputeEntityDisplayName(
                                 name    : string.Format(GetLocalizedString(SR.ID8013, culture), button.ToString(CultureInfo.InvariantCulture)),
                                 endpoint: endpoint,
                                 culture : culture,
@@ -1388,7 +1390,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                                 .. "23e04eeb-8b35-44c8-87da-aed3829ce07d"u8,
                                 .. Encoding.UTF8.GetBytes(button.ToString(CultureInfo.InvariantCulture))
                             ]),
-                            ["name"] = ComputeEntityName(
+                            ["name"] = ComputeEntityDisplayName(
                                 name    : string.Format(GetLocalizedString(SR.ID8014, culture), button.ToString(CultureInfo.InvariantCulture)),
                                 endpoint: endpoint,
                                 culture : culture,
@@ -1406,7 +1408,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     {
                         ["platform"] = "button",
                         ["unique_id"] = ComputeEntityUniqueId(endpoint, "be2887c3-f4ae-4935-bad6-1ffb1227d28b"u8),
-                        ["name"] = ComputeEntityName(
+                        ["name"] = ComputeEntityDisplayName(
                             name    : GetLocalizedString(SR.ID8015, culture),
                             endpoint: endpoint,
                             culture : culture,
@@ -1420,7 +1422,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     {
                         ["platform"] = "button",
                         ["unique_id"] = ComputeEntityUniqueId(endpoint, "81e3f75a-fab3-4842-bb5e-1531d20290dd"u8),
-                        ["name"] = ComputeEntityName(
+                        ["name"] = ComputeEntityDisplayName(
                             name    : GetLocalizedString(SR.ID8016, culture),
                             endpoint: endpoint,
                             culture : culture,
@@ -1434,7 +1436,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     {
                         ["platform"] = "button",
                         ["unique_id"] = ComputeEntityUniqueId(endpoint, "3f069e7f-7c8f-4730-b067-9a944f61700b"u8),
-                        ["name"] = ComputeEntityName(
+                        ["name"] = ComputeEntityDisplayName(
                             name    : GetLocalizedString(SR.ID8017, culture),
                             endpoint: endpoint,
                             culture : culture,
@@ -1448,7 +1450,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     {
                         ["platform"] = "button",
                         ["unique_id"] = ComputeEntityUniqueId(endpoint, "23e04eeb-8b35-44c8-87da-aed3829ce07d"u8),
-                        ["name"] = ComputeEntityName(
+                        ["name"] = ComputeEntityDisplayName(
                             name    : GetLocalizedString(SR.ID8018, culture),
                             endpoint: endpoint,
                             culture : culture,
@@ -1477,7 +1479,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                                 .. "63a92ba4-bec3-453e-a44a-9219e4f4d478"u8,
                                 .. Encoding.UTF8.GetBytes(button.ToString(CultureInfo.InvariantCulture))
                             ]),
-                            ["name"] = ComputeEntityName(
+                            ["name"] = ComputeEntityDisplayName(
                                 name    : string.Format(GetLocalizedString(SR.ID8019, culture), button.ToString(CultureInfo.InvariantCulture)),
                                 endpoint: endpoint,
                                 culture : culture,
@@ -1495,7 +1497,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                                 .. "e524f94b-9862-4da4-8f57-82c220e4560c"u8,
                                 .. Encoding.UTF8.GetBytes(button.ToString(CultureInfo.InvariantCulture))
                             ]),
-                            ["name"] = ComputeEntityName(
+                            ["name"] = ComputeEntityDisplayName(
                                 name    : string.Format(GetLocalizedString(SR.ID8020, culture), button.ToString(CultureInfo.InvariantCulture)),
                                 endpoint: endpoint,
                                 culture : culture,
@@ -1513,7 +1515,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                                 .. "bf90ede8-9078-4817-8ec4-ef762c3e2077"u8,
                                 .. Encoding.UTF8.GetBytes(button.ToString(CultureInfo.InvariantCulture))
                             ]),
-                            ["name"] = ComputeEntityName(
+                            ["name"] = ComputeEntityDisplayName(
                                 name    : string.Format(GetLocalizedString(SR.ID8014, culture), button.ToString(CultureInfo.InvariantCulture)),
                                 endpoint: endpoint,
                                 culture : culture,
@@ -1531,7 +1533,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                                 .. "73ff2263-9962-443a-89a1-f209fba81948"u8,
                                 .. Encoding.UTF8.GetBytes(button.ToString(CultureInfo.InvariantCulture))
                             ]),
-                            ["name"] = ComputeEntityName(
+                            ["name"] = ComputeEntityDisplayName(
                                 name    : string.Format(GetLocalizedString(SR.ID8021, culture), button.ToString(CultureInfo.InvariantCulture)),
                                 endpoint: endpoint,
                                 culture : culture,
@@ -1549,7 +1551,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     {
                         ["platform"] = "button",
                         ["unique_id"] = ComputeEntityUniqueId(endpoint, "63a92ba4-bec3-453e-a44a-9219e4f4d478"u8),
-                        ["name"] = ComputeEntityName(
+                        ["name"] = ComputeEntityDisplayName(
                             name    : GetLocalizedString(SR.ID8022, culture),
                             endpoint: endpoint,
                             culture : culture,
@@ -1563,7 +1565,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     {
                         ["platform"] = "button",
                         ["unique_id"] = ComputeEntityUniqueId(endpoint, "e524f94b-9862-4da4-8f57-82c220e4560c"u8),
-                        ["name"] = ComputeEntityName(
+                        ["name"] = ComputeEntityDisplayName(
                             name    : GetLocalizedString(SR.ID8023, culture),
                             endpoint: endpoint,
                             culture : culture,
@@ -1577,7 +1579,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     {
                         ["platform"] = "button",
                         ["unique_id"] = ComputeEntityUniqueId(endpoint, "bf90ede8-9078-4817-8ec4-ef762c3e2077"u8),
-                        ["name"] = ComputeEntityName(
+                        ["name"] = ComputeEntityDisplayName(
                             name    : GetLocalizedString(SR.ID8018, culture),
                             endpoint: endpoint,
                             culture : culture,
@@ -1591,7 +1593,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     {
                         ["platform"] = "button",
                         ["unique_id"] = ComputeEntityUniqueId(endpoint, "73ff2263-9962-443a-89a1-f209fba81948"u8),
-                        ["name"] = ComputeEntityName(
+                        ["name"] = ComputeEntityDisplayName(
                             name    : GetLocalizedString(SR.ID8024, culture),
                             endpoint: endpoint,
                             culture : culture,
@@ -1609,7 +1611,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 {
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "9065ccb4-d2c6-47f5-b118-e3d2ecbe20c3"u8),
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8026, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1623,7 +1625,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 {
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "4006cf9e-620c-49d4-81b3-ab060d376966"u8),
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8027, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1637,7 +1639,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 {
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "d13fdcd2-c974-490a-b544-436a91785ffa"u8),
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8028, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1657,7 +1659,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["entity_category"] = "diagnostic",
                     ["device_class"] = "battery",
                     ["off_delay"] = 3600,
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8029, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1672,7 +1674,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "7f7625f0-2461-4804-9cae-829a1040cd93"u8),
                     ["entity_category"] = "diagnostic",
                     ["icon"] = "mdi:battery-check",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8030, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1692,7 +1694,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["entity_category"] = "diagnostic",
                     ["device_class"] = "battery",
                     ["unit_of_measurement"] = "%",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8031, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1709,7 +1711,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "sensor",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "3a92e77f-3910-4a20-9d19-caa1961dc33d"u8),
                     ["entity_category"] = "diagnostic",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8032, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1724,7 +1726,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "e4fa32b3-9e9f-43b5-810a-cdb75acf44e5"u8),
                     ["entity_category"] = "diagnostic",
                     ["icon"] = "mdi:help",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8033, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1742,7 +1744,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "sensor",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "1091f326-0c22-4c59-af04-d0a6ee429a0c"u8),
                     ["entity_category"] = "diagnostic",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8034, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1757,7 +1759,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "0371ccbb-52fd-4288-a943-b2f04a7b1e8b"u8),
                     ["entity_category"] = "diagnostic",
                     ["icon"] = "mdi:help",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8035, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1775,7 +1777,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "sensor",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "a8de45b2-0bb5-4375-b33b-0869623e40a7"u8),
                     ["entity_category"] = "diagnostic",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8036, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1790,7 +1792,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "aa1968e6-f232-4b96-a29f-0e64de093bb0"u8),
                     ["entity_category"] = "diagnostic",
                     ["icon"] = "mdi:help",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8037, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1808,7 +1810,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "select",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "205a01a1-ba4c-4e9b-a19a-c1589c445cbb"u8),
                     ["icon"] = "mdi:radiator",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8039, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1851,7 +1853,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "7a9130b9-675a-437d-b806-cbfe6f6e20a6"u8),
                     ["entity_category"] = "diagnostic",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8062, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1869,7 +1871,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "select",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "f5f57920-d758-4ca8-8161-2614d4abeef0"u8),
                     ["icon"] = "mdi:radiator",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8045, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1945,7 +1947,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "787582e8-0c5f-4c97-9277-0ad23dab4024"u8),
                     ["entity_category"] = "diagnostic",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8063, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1963,7 +1965,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "switch",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "178d9f9b-e87a-4ebf-8db3-80e1e1a091df"u8),
                     ["icon"] = "mdi:radiator-off",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8113, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1978,7 +1980,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "ecc822a6-57ab-4352-8d2c-d85dc73df5da"u8),
                     ["entity_category"] = "diagnostic",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8114, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -1999,7 +2001,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["state_class"] = "total_increasing",
                     ["unit_of_measurement"] = "kWh",
                     ["suggested_display_precision"] = 0,
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8064, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2017,7 +2019,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["state_class"] = "total_increasing",
                     ["unit_of_measurement"] = "kWh",
                     ["suggested_display_precision"] = 0,
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8065, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2035,7 +2037,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["state_class"] = "total_increasing",
                     ["unit_of_measurement"] = "kWh",
                     ["suggested_display_precision"] = 0,
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8115, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2053,7 +2055,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["state_class"] = "total_increasing",
                     ["unit_of_measurement"] = "kWh",
                     ["suggested_display_precision"] = 0,
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8066, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2071,7 +2073,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["state_class"] = "total_increasing",
                     ["unit_of_measurement"] = "kWh",
                     ["suggested_display_precision"] = 0,
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8116, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2089,7 +2091,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["state_class"] = "total_increasing",
                     ["unit_of_measurement"] = "kWh",
                     ["suggested_display_precision"] = 0,
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8067, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2107,7 +2109,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["state_class"] = "total_increasing",
                     ["unit_of_measurement"] = "kWh",
                     ["suggested_display_precision"] = 0,
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8117, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2125,7 +2127,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["state_class"] = "total_increasing",
                     ["unit_of_measurement"] = "kWh",
                     ["suggested_display_precision"] = 0,
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8068, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2143,7 +2145,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["state_class"] = "total_increasing",
                     ["unit_of_measurement"] = "kWh",
                     ["suggested_display_precision"] = 0,
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8118, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2159,7 +2161,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "e07f0687-6ca1-47d9-a5b7-b20c0e79775a"u8),
                     ["device_class"] = "enum",
                     ["icon"] = "mdi:receipt-text-outline",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8069, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2186,7 +2188,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 {
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "2eddee8f-7c81-47ea-a775-785e9dfb5c26"u8),
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8073, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2205,7 +2207,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "31eda1f3-343f-4cd7-9f56-ea792fcaec7f"u8),
                     ["device_class"] = "enum",
                     ["icon"] = "mdi:receipt-text-outline",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8074, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2228,7 +2230,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "280fd1d1-4220-42ec-bf70-69936b728eb2"u8),
                     ["device_class"] = "running",
                     ["icon"] = "mdi:transmission-tower-off",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8077, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2242,7 +2244,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "91e32508-61fa-46e3-ba57-32166b2de116"u8),
                     ["entity_category"] = "diagnostic",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8078, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2257,7 +2259,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "df24321d-01e8-4d1a-9cca-92ece18934b4"u8),
                     ["entity_category"] = "diagnostic",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8079, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2276,7 +2278,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "46c1f892-f9bf-46b6-8658-fed1d7eb177b"u8),
                     ["entity_category"] = "diagnostic",
                     ["device_class"] = "timestamp",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8080, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2290,7 +2292,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "5e9b5094-b028-492c-8be4-5b73139e2c57"u8),
                     ["entity_category"] = "diagnostic",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name: GetLocalizedString(SR.ID8081, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2308,7 +2310,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "select",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "733d9bf6-fd89-4ce1-bd71-d12a1c6a846e"u8),
                     ["icon"] = "mdi:water-boiler",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8109, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2346,7 +2348,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "344b6548-196d-42de-b627-22530cc28f07"u8),
                     ["device_class"] = "running",
                     ["icon"] = "mdi:fire",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8085, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2362,7 +2364,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "bb186d7c-f49d-4aa2-8770-a0fdcf9de123"u8),
                     ["entity_category"] = "diagnostic",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8086, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2381,7 +2383,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "2dd476d5-a35a-442a-a3f2-4c2621dcf375"u8),
                     ["device_class"] = "enum",
                     ["icon"] = "mdi:shield-home-outline",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8087, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2420,7 +2422,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["entity_category"] = "diagnostic",
                     ["device_class"] = "running",
                     ["icon"] = "mdi:link-box",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8107, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2443,7 +2445,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "d04dc07d-b614-4e3e-aeac-ccaead40d919"u8),
                     ["entity_category"] = "config",
                     ["icon"] = "mdi:link",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8094, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2459,7 +2461,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "55a25c45-cb7a-4b74-baa4-7f9b87465d1a"u8),
                     ["entity_category"] = "config",
                     ["icon"] = "mdi:link-off",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8095, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2479,7 +2481,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["entity_category"] = "diagnostic",
                     ["device_class"] = "opening",
                     ["icon"] = "mdi:wifi-strength-lock-open-outline",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8108, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2504,7 +2506,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "5ea35f24-9a6c-4d62-b000-85e6a9ef5380"u8),
                     ["entity_category"] = "diagnostic",
                     ["icon"] = "mdi:sine-wave",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8096, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2519,7 +2521,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "abda41d7-1b4c-41cc-99b9-81b7bc5801d3"u8),
                     ["entity_category"] = "diagnostic",
                     ["icon"] = "mdi:counter",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8105, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2534,7 +2536,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "b7355e3d-0137-41e7-90fa-8b81b9530466"u8),
                     ["entity_category"] = "diagnostic",
                     ["icon"] = "mdi:sine-wave",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8097, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2550,7 +2552,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "6c550d13-cbd5-4a7a-b445-1c30e9b83c65"u8),
                     ["entity_category"] = "diagnostic",
                     ["icon"] = "mdi:counter",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8106, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2565,7 +2567,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "f366a06c-6d7f-4741-a99a-490fedeabf9f"u8),
                     ["icon"] = "mdi:new-box",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8098, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2580,7 +2582,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "1c56979a-3ad2-4b9b-9116-cd7321416b6a"u8),
                     ["icon"] = "mdi:download-network",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8099, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2595,7 +2597,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "63096c5c-3fba-4ea7-a30d-3568b0680e18"u8),
                     ["icon"] = "mdi:upload-network",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8100, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2611,7 +2613,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "09953b7d-0e18-4fc9-9b8c-2a11b52a15c5"u8),
                     ["icon"] = "mdi:lock-open",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8101, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2626,7 +2628,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "7e344b36-199e-4a43-987f-59fccacc859b"u8),
                     ["icon"] = "mdi:lock",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8102, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2641,7 +2643,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "f6a3d89f-a3a4-4776-a6b0-a0e3328183ee"u8),
                     ["icon"] = "mdi:eye-check",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8103, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2656,7 +2658,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["platform"] = "button",
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "35f91e70-674d-4977-9475-ba231553051d"u8),
                     ["icon"] = "mdi:eye-remove",
-                    ["name"] = ComputeEntityName(
+                    ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8104, culture),
                         endpoint: endpoint,
                         culture : culture,
@@ -2683,13 +2685,18 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
         {
             var node = new JsonObject
             {
-                ["identifiers"] = new JsonArray([ComputeDeviceUniqueId(device)]),
+                ["identifiers"] = new JsonArray(
+                [
+                    // Use the device's object ID if set, otherwise fall back to the device name.
+                    device.GetStringSetting(OpenNettySettings.HomeAssistantObjectId)
+                        ?? SanitizeDiscoveryObjectId(device.Name)
+                ]),
                 ["manufacturer"] = Enum.GetName(device.Identity.Brand),
                 ["model_id"] = device.Identity.Model,
-                ["serial_number"] = device.Identifier.ToString(),
-                ["name"] = device.GetStringSetting(OpenNettySettings.HomeAssistantDeviceName) is { Length: > 0 } name
-                    ? name
-                    : $"{Enum.GetName(device.Identity.Brand)} {device.Identity.Model} ({device.Identifier})"
+                ["name"] = device.GetStringSetting(OpenNettySettings.HomeAssistantDeviceName)
+                    ?? (device.Identifier is not null
+                        ? $"{Enum.GetName(device.Identity.Brand)} {device.Identity.Model} ({device.Identifier})"
+                        : $"{Enum.GetName(device.Identity.Brand)} {device.Identity.Model}")
             };
 
             var description = device.Identity.GetDescription(culture);
@@ -2698,14 +2705,25 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 node["model"] = description;
             }
 
-            if (device.Identifier.Type is OpenNettyDeviceIdentifierType.MacAddress)
+            if (device.Identifier?.Type is OpenNettyDeviceIdentifierType.NitooSerialNumber or
+                                           OpenNettyDeviceIdentifierType.ScsSerialNumber or
+                                           OpenNettyDeviceIdentifierType.ZigbeeSerialNumber)
             {
-                node["connections"] = new JsonArray([new JsonArray(["mac", OpenNettyDeviceIdentifier.ToMacAddress(device.Identifier)])]);
+                node["serial_number"] = device.Identifier.Value.ToString();
+            }
+
+            if (device.Identifier?.Type is OpenNettyDeviceIdentifierType.MacAddress)
+            {
+                node["connections"] = new JsonArray(
+                [
+                    new JsonArray(["mac", OpenNettyDeviceIdentifier.ToMacAddress(device.Identifier.Value)])
+                ]);
             }
 
             if (device.Gateway is OpenNettyGateway gateway)
             {
-                node["via_device"] = ComputeDeviceUniqueId(gateway.Device);
+                node["via_device"] = gateway.Device.GetStringSetting(OpenNettySettings.HomeAssistantObjectId)
+                    ?? SanitizeDiscoveryObjectId(gateway.Device.Name);
             }
 
             if (device.GetStringSetting(OpenNettySettings.HomeAssistantSuggestedArea) is { Length: > 0 } area)
@@ -2720,10 +2738,14 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
         {
             var node = new JsonObject
             {
-                ["identifiers"] = new JsonArray([ComputeVirtualDeviceUniqueId(endpoint)]),
-                ["name"] = endpoint.GetStringSetting(OpenNettySettings.HomeAssistantDeviceName) is { Length: > 0 } name
-                    ? name
-                    : endpoint.Address?.Type switch
+                ["identifiers"] = new JsonArray(
+                [
+                    // Use the endpoint's object ID if set, otherwise fall back to the endpoint name.
+                    endpoint.GetStringSetting(OpenNettySettings.HomeAssistantObjectId)
+                        ?? SanitizeDiscoveryObjectId(endpoint.Name)
+                ]),
+                ["name"] = endpoint.GetStringSetting(OpenNettySettings.HomeAssistantDeviceName)
+                    ?? endpoint.Address?.Type switch
                     {
                         OpenNettyAddressType.Nitoo           => GetLocalizedString(SR.ID8121, culture),
                         OpenNettyAddressType.Zigbee          => GetLocalizedString(SR.ID8122, culture),
@@ -2736,7 +2758,8 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
 
             if (endpoint.Gateway is OpenNettyGateway gateway)
             {
-                node["via_device"] = ComputeDeviceUniqueId(gateway.Device);
+                node["via_device"] = gateway.Device.GetStringSetting(OpenNettySettings.HomeAssistantObjectId)
+                    ?? SanitizeDiscoveryObjectId(gateway.Device.Name);
             }
 
             if (endpoint.GetStringSetting(OpenNettySettings.HomeAssistantSuggestedArea) is { Length: > 0 } area)
@@ -2747,19 +2770,6 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
             return node;
         }
 
-        static string ComputeDeviceUniqueId(OpenNettyDevice device)
-        {
-            var hash = new XxHash128();
-            hash.Append(MemoryMarshal.AsBytes<char>(Enum.GetName(device.Definition.Protocol)));
-            hash.Append(MemoryMarshal.AsBytes<char>(Enum.GetName(device.Identifier.Type)));
-            hash.Append(MemoryMarshal.AsBytes<char>(device.Identifier.ToString()));
-
-            return Base64Url.EncodeToString(hash.GetCurrentHash());
-        }
-
-        static string ComputeVirtualDeviceUniqueId(OpenNettyEndpoint endpoint)
-            => Base64Url.EncodeToString(XxHash128.Hash(MemoryMarshal.AsBytes<char>(endpoint.Name)));
-
         static string ComputeEntityUniqueId(OpenNettyEndpoint endpoint, ReadOnlySpan<byte> discriminator)
         {
             var hash = new XxHash128();
@@ -2769,7 +2779,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
             return Base64Url.EncodeToString(hash.GetCurrentHash());
         }
 
-        static string ComputeEntityName(string name, OpenNettyEndpoint endpoint, CultureInfo culture, int count)
+        static string ComputeEntityDisplayName(string name, OpenNettyEndpoint endpoint, CultureInfo culture, int count)
         {
             if (count is < 2)
             {
@@ -2792,7 +2802,58 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
             return name;
         }
 
-        static bool IsValidNodeIdCharacter(char character) => char.IsLetterOrDigit(character) || character is '-' or '_';
+        static string SanitizeDiscoveryObjectId(string name)
+        {
+            var builder = new StringBuilder(name.Length);
+            var separator = true;
+
+            foreach (var character in name.Normalize(NormalizationForm.FormD))
+            {
+                if (CharUnicodeInfo.GetUnicodeCategory(character) is UnicodeCategory.NonSpacingMark)
+                {
+                    continue;
+                }
+
+                switch (character)
+                {
+                    case 'ß':
+                        builder.Append("ss");
+                        separator = false;
+                        continue;
+
+                    case 'æ':
+                    case 'Æ':
+                        builder.Append("ae");
+                        separator = false;
+                        continue;
+
+                    case 'œ':
+                    case 'Œ':
+                        builder.Append("oe");
+                        separator = false;
+                        continue;
+                }
+
+                if (char.IsAsciiLetterOrDigit(character))
+                {
+                    builder.Append(char.ToLowerInvariant(character));
+                    separator = false;
+                }
+
+                else if (!separator)
+                {
+                    builder.Append('-');
+                    separator = true;
+                }
+            }
+
+            if (builder.Length is > 0 && builder[^1] is '-')
+            {
+                builder.Length--;
+            }
+
+            return builder.ToString();
+        }
 
         static string GetLocalizedString(string name, CultureInfo culture) => SR.ResourceManager.GetString(name, culture)!;
 

--- a/src/OpenNetty/OpenNettyBuilder.cs
+++ b/src/OpenNetty/OpenNettyBuilder.cs
@@ -9,7 +9,6 @@ using System.ComponentModel;
 using System.Globalization;
 using System.IO.Ports;
 using System.Net;
-using System.Text;
 using System.Xml.Linq;
 using Microsoft.Extensions.FileProviders;
 
@@ -292,8 +291,9 @@ public sealed class OpenNettyBuilder
                         ? GetDevice(options.Gateways, endpoint.Parent.Parent)
                         : null;
 
-                var unit = device is not null && endpoint.Parent?.Name == "Unit" ? GetUnit(endpoint.Parent,
-                    (byte?) (uint?) endpoint.Parent.Attribute("Id") ?? throw new InvalidOperationException(SR.FormatID0078("Id"))) : null;
+                var unit = device is not null && endpoint.Parent?.Name == "Unit"
+                    ? GetUnit(device.Definition, endpoint.Parent)
+                    : null;
 
                 var type = (string?) endpoint.Attribute("Type") switch
                 {
@@ -344,9 +344,9 @@ public sealed class OpenNettyBuilder
                             identifier: identifier,
                             unit      : (byte?) (uint?) endpoint.Attribute("Unit") ?? unit?.Definition.Id ?? 0),
 
-                    OpenNettyAddressType.Nitoo when device is not null
+                    OpenNettyAddressType.Nitoo when device?.Identifier is OpenNettyDeviceIdentifier identifier
                         => OpenNettyAddress.FromNitooAddress(
-                            identifier: device.Identifier,
+                            identifier: identifier,
                             unit      : (byte?) (uint?) endpoint.Attribute("Unit") ?? unit?.Definition.Id ?? 0),
 
                     OpenNettyAddressType.ScsLightPoint => OpenNettyAddress.FromScsLightPointAddress(
@@ -364,9 +364,9 @@ public sealed class OpenNettyBuilder
                             identifier: identifier,
                             unit      : (byte?) (uint?) endpoint.Attribute("Unit") ?? unit?.Definition.Id ?? 0),
 
-                    OpenNettyAddressType.Zigbee when device is not null
+                    OpenNettyAddressType.Zigbee when device?.Identifier is OpenNettyDeviceIdentifier identifier
                         => OpenNettyAddress.FromZigbeeAddress(
-                            identifier: device.Identifier,
+                            identifier: identifier,
                             unit      : (byte?) (uint?) endpoint.Attribute("Unit") ?? unit?.Definition.Id ?? 0),
 
                     null => (OpenNettyAddress?) null,
@@ -388,91 +388,13 @@ public sealed class OpenNettyBuilder
                             options.Gateways.FirstOrDefault(gateway => gateway.Protocol == protocol) ??
                             throw new InvalidOperationException(SR.FormatID0106(protocol)),
                     Medium = device?.Definition.Medium,
-                    Name = name ?? ComputeDefaultEndpointName(protocol, address, device, unit),
+                    Name = name ?? OpenNettyUtilities.ComputeDefaultEndpointName(protocol, address, device, unit),
                     Protocol = protocol,
                     Settings = GetSettings(endpoint),
                     Unit = unit
                 });
             }
         });
-
-        static string ComputeDefaultEndpointName(
-            OpenNettyProtocol protocol, OpenNettyAddress? address, OpenNettyDevice? device, OpenNettyUnit? unit)
-        {
-            var builder = new StringBuilder(Enum.GetName(protocol));
-            builder.Append('/');
-
-            switch (protocol)
-            {
-                case OpenNettyProtocol.Nitoo or OpenNettyProtocol.Zigbee:
-                    if (device is null)
-                    {
-                        throw new InvalidOperationException(SR.GetResourceString(SR.ID0104));
-                    }
-
-                    builder.Append(new string(device.Identifier.ToString().Where(char.IsAsciiDigit).ToArray()));
-
-                    if (unit is not null)
-                    {
-                        builder.Append('/');
-                        builder.Append(unit.Definition.Id);
-                    }
-                    break;
-
-                case OpenNettyProtocol.Scs when address?.Type is OpenNettyAddressType.ScsLightPoint:
-                    var (extension, general, group, area, point) = OpenNettyAddress.ToScsLightPointAddress(address.Value);
-
-                    if (OpenNettyAddress.IsScsLightPointAreaAddress(address.Value))
-                    {
-                        builder.Append("light-point-area");
-                        builder.Append('/');
-                        builder.Append(extension);
-                        builder.Append('/');
-                        builder.Append(area);
-                    }
-
-                    else if (OpenNettyAddress.IsScsLightPointGeneralAddress(address.Value))
-                    {
-                        builder.Append("light-point-general");
-                        builder.Append('/');
-                        builder.Append(extension);
-                    }
-
-                    else if (OpenNettyAddress.IsScsLightPointGroupAddress(address.Value))
-                    {
-                        builder.Append("light-point-group");
-                        builder.Append('/');
-                        builder.Append(extension);
-                        builder.Append('/');
-                        builder.Append(group);
-                    }
-
-                    else if (OpenNettyAddress.IsScsLightPointPointToPointAddress(address.Value))
-                    {
-                        builder.Append("light-point-point-to-point");
-                        builder.Append('/');
-                        builder.Append(extension);
-                        builder.Append('/');
-                        builder.Append(area);
-                        builder.Append('/');
-                        builder.Append(point);
-                    }
-
-                    builder.Append(address.Value.ToString());
-                    break;
-
-                case OpenNettyProtocol.Scs when address?.Type is OpenNettyAddressType.ScsScenarioPlus:
-                    builder.Append("scs-scenario-plus");
-                    builder.Append('/');
-                    builder.Append(OpenNettyAddress.ToScsScenarioPlusAddress(address.Value));
-                    break;
-
-                case OpenNettyProtocol.Scs:
-                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0105));
-            }
-
-            return builder.ToString();
-        }
 
         static ImmutableHashSet<OpenNettyCapability> GetCapabilities(XElement element) =>
             element.Elements("Capability")
@@ -482,8 +404,7 @@ public sealed class OpenNettyBuilder
 
         static OpenNettyDevice GetDevice(IReadOnlyList<OpenNettyGateway> gateways, XElement element)
         {
-            var brand = (string?) element.Attribute("Brand");
-            if (string.IsNullOrEmpty(brand))
+            if (!Enum.TryParse((string?) element.Attribute("Brand"), out OpenNettyBrand brand))
             {
                 throw new InvalidOperationException(SR.FormatID0084("Brand"));
             }
@@ -494,8 +415,20 @@ public sealed class OpenNettyBuilder
                 throw new InvalidOperationException(SR.FormatID0084("Model"));
             }
 
-            var definition = OpenNettyDevices.GetDeviceByModel(Enum.Parse<OpenNettyBrand>(brand), model)
-                ?? throw new InvalidOperationException(SR.FormatID0085(brand, model));
+            var definition = OpenNettyDevices.GetDeviceDefinitionByModel(brand, model);
+            var identity = definition.GetIdentity(brand, model);
+            var identifier = GetDeviceIdentifier(definition, element);
+
+            var name = (string?) element.Attribute("Name");
+            if (string.IsNullOrEmpty(name))
+            {
+                if (identifier is null)
+                {
+                    throw new InvalidOperationException(SR.FormatID0108("Name", "SerialNumber", "MacAddress"));
+                }
+
+                name = $"{Enum.GetName(identity.Brand)} {identity.Model} ({identifier})";
+            }
 
             var gateway = definition.HasCapability(OpenNettyCapabilities.OpenWebNetGateway)
                 ? null
@@ -511,17 +444,15 @@ public sealed class OpenNettyBuilder
             {
                 Definition = definition,
                 Gateway = gateway,
-                Identifier = GetIdentifier(definition, element),
-                Identity = definition.Identities.Single(identity =>
-                    identity.Brand == Enum.Parse<OpenNettyBrand>(brand) && identity.Model == model),
+                Identifier = identifier,
+                Identity = identity,
+                Name = name,
                 Settings = GetSettings(element),
-                Units = [.. element.Elements("Unit").Select(static element =>
-                    GetUnit(element, (byte?) (uint?) element.Attribute("Id")
-                        ?? throw new InvalidOperationException(SR.FormatID0078("Id"))))]
+                Units = [.. element.Elements("Unit").Select(element => GetUnit(definition, element))]
             };
         }
 
-        static OpenNettyDeviceIdentifier GetIdentifier(OpenNettyDeviceDefinition definition, XElement element)
+        static OpenNettyDeviceIdentifier? GetDeviceIdentifier(OpenNettyDeviceDefinition definition, XElement element)
         {
             if (definition.Protocol is OpenNettyProtocol.Nitoo)
             {
@@ -556,7 +487,7 @@ public sealed class OpenNettyBuilder
                 return OpenNettyDeviceIdentifier.FromMacAddress(address);
             }
 
-            throw new InvalidOperationException(SR.GetResourceString(SR.FormatID0108("SerialNumber", "MacAddress")));
+            return null;
         }
 
         static ImmutableDictionary<OpenNettySetting, string> GetSettings(XElement element) =>
@@ -570,26 +501,14 @@ public sealed class OpenNettyBuilder
             FunctionCode = (byte?) (uint?) element.Attribute("FunctionCode") ?? throw new InvalidOperationException(SR.FormatID0088("FunctionCode"))
         };
 
-        static OpenNettyUnit GetUnit(XElement element, byte unit)
+        static OpenNettyUnit GetUnit(OpenNettyDeviceDefinition definition, XElement element)
         {
-            var brand = (string?) element.Parent?.Attribute("Brand");
-            if (string.IsNullOrEmpty(brand))
-            {
-                throw new InvalidOperationException(SR.FormatID0084("Brand"));
-            }
-
-            var model = (string?) element.Parent?.Attribute("Model");
-            if (string.IsNullOrEmpty(model))
-            {
-                throw new InvalidOperationException(SR.FormatID0084("Model"));
-            }
-
-            var definition = OpenNettyDevices.GetUnitByModel(Enum.Parse<OpenNettyBrand>(brand), model, unit)
-                ?? throw new InvalidOperationException(SR.FormatID0087(unit, brand, model));
+            var identifier = (byte?) (uint?) element.Attribute("Id")
+                ?? throw new InvalidOperationException(SR.FormatID0078("Id"));
 
             return new()
             {
-                Definition = definition,
+                Definition = definition.GetUnitDefinition(identifier),
                 Scenarios = [.. element.Elements("Scenario").Select(GetScenario)],
                 Settings = GetSettings(element)
             };

--- a/src/OpenNetty/OpenNettyConfiguration.cs
+++ b/src/OpenNetty/OpenNettyConfiguration.cs
@@ -4,10 +4,8 @@
  * the license and the contributors participating to this project.
  */
 
-using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Globalization;
-using System.Text;
 using Microsoft.Extensions.Options;
 
 namespace OpenNetty;
@@ -25,33 +23,34 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
 
         foreach (var device in options.Devices)
         {
-            // If an endpoint targeting the device was configured by the user, do not override it.
+            if (device.Identifier is null)
+            {
+                continue;
+            }
+
+            // If an endpoint targeting the device was configured by the user, do not overwrite it.
             if (!options.Endpoints.Exists(endpoint => endpoint.Device == device && endpoint.Unit is null))
             {
+                var address = device.Definition.Protocol switch
+                {
+                    OpenNettyProtocol.Nitoo  => OpenNettyAddress.FromNitooAddress(device.Identifier.Value,  unit: 0),
+                    OpenNettyProtocol.Zigbee => OpenNettyAddress.FromZigbeeAddress(device.Identifier.Value, unit: 0),
+
+                    _ => null as OpenNettyAddress?
+                };
+
                 options.Endpoints.Add(new OpenNettyEndpoint
                 {
-                    Address = device.Definition.Protocol switch
-                    {
-                        OpenNettyProtocol.Nitoo  => OpenNettyAddress.FromNitooAddress(device.Identifier,  unit: 0),
-                        OpenNettyProtocol.Zigbee => OpenNettyAddress.FromZigbeeAddress(device.Identifier, unit: 0),
-
-                        _ => null
-                    },
+                    Address = address,
                     Capabilities = [],
                     Device = device,
                     Gateway = device.Gateway ?? options.Gateways.FirstOrDefault(gateway => gateway.Device == device)
                         ?? throw new InvalidOperationException(SR.FormatID0107("Gateway")),
                     Medium = device.Definition.Medium,
-                    Name = ComputeDefaultEndpointName(device),
+                    Name = OpenNettyUtilities.ComputeDefaultEndpointName(device.Definition.Protocol, address, device, unit: null),
                     Protocol = device.Definition.Protocol,
-                    Settings = ImmutableDictionary.Create<OpenNettySetting, string>()
+                    Settings = []
                 });
-
-                static string ComputeDefaultEndpointName(OpenNettyDevice device)
-                    => new StringBuilder(Enum.GetName(device.Definition.Protocol))
-                        .Append('/')
-                        .Append(new string(device.Identifier.ToString().Where(char.IsAsciiHexDigit).ToArray()))
-                        .ToString();
             }
 
             // Add implicit endpoints for all the units that have not been explicitly added by the user.
@@ -65,38 +64,34 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
                         continue;
                     }
 
+                    var address = device.Definition.Protocol switch
+                    {
+                        OpenNettyProtocol.Nitoo  => OpenNettyAddress.FromNitooAddress(device.Identifier.Value,  unit: definition.Id),
+                        OpenNettyProtocol.Zigbee => OpenNettyAddress.FromZigbeeAddress(device.Identifier.Value, unit: definition.Id),
+
+                        _ => null as OpenNettyAddress?
+                    };
+
+                    var unit = device.Units.SingleOrDefault(unit => unit.Definition == definition) ?? new OpenNettyUnit
+                    {
+                        Definition = definition,
+                        Scenarios = [],
+                        Settings = []
+                    };
+
                     options.Endpoints.Add(new OpenNettyEndpoint
                     {
-                        Address = device.Definition.Protocol switch
-                        {
-                            OpenNettyProtocol.Nitoo  => OpenNettyAddress.FromNitooAddress(device.Identifier,  unit: definition.Id),
-                            OpenNettyProtocol.Zigbee => OpenNettyAddress.FromZigbeeAddress(device.Identifier, unit: definition.Id),
-
-                            _ => null
-                        },
+                        Address = address,
                         Capabilities = [],
                         Device = device,
                         Gateway = device.Gateway ?? options.Gateways.FirstOrDefault(gateway => gateway.Device == device)
                             ?? throw new InvalidOperationException(SR.FormatID0107("Gateway")),
                         Medium = device.Definition.Medium,
-                        Name = ComputeDefaultEndpointName(device, definition),
+                        Name = OpenNettyUtilities.ComputeDefaultEndpointName(device.Definition.Protocol, address, device, unit),
                         Protocol = device.Definition.Protocol,
-                        Settings = ImmutableDictionary.Create<OpenNettySetting, string>(),
-                        Unit = device.Units.SingleOrDefault(unit => unit.Definition == definition) ?? new OpenNettyUnit
-                        {
-                            Definition = definition,
-                            Scenarios = [],
-                            Settings = ImmutableDictionary.Create<OpenNettySetting, string>()
-                        }
+                        Settings = [],
+                        Unit = unit
                     });
-
-                    static string ComputeDefaultEndpointName(OpenNettyDevice device, OpenNettyUnitDefinition unit)
-                        => new StringBuilder(Enum.GetName(device.Definition.Protocol))
-                            .Append('/')
-                            .Append(new string(device.Identifier.ToString().Where(char.IsAsciiHexDigit).ToArray()))
-                            .Append('/')
-                            .Append(unit.Id)
-                            .ToString();
                 }
             }
         }
@@ -111,34 +106,69 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
 
         if (options.Gateways.Count is 0)
         {
-            builder.AddError(SR.GetResourceString(SR.ID0126));
+            builder.AddError(SR.GetResourceString(SR.ID2017));
         }
 
-        if (options.Devices.GroupBy(static device => device.Identifier)
+        switch (options.Devices.GroupBy(static device => device.Identifier)
+            .Where(static group => group.Key is not null)
             .Where(static group => group.Count() is > 1)
             .Select(static group => group.Key)
             .OfType<OpenNettyDeviceIdentifier?>()
-            .FirstOrDefault() is OpenNettyDeviceIdentifier identifier)
+            .FirstOrDefault())
         {
-            builder.AddError(SR.FormatID2012(identifier.ToString()));
+            case OpenNettyDeviceIdentifier value:
+                builder.AddError(SR.FormatID2012(value.ToString()));
+                break;
         }
 
-        if (options.Endpoints.GroupBy(static endpoint => endpoint.Name)
+        switch (options.Devices.GroupBy(static device => device.Name)
+            .Where(static device => device.Count() is > 1)
+            .Select(static device => device.Key)
+            .OfType<string?>()
+            .FirstOrDefault())
+        {
+            case string value:
+                builder.AddError(SR.FormatID2019(value));
+                break;
+        }
+
+        switch (options.Endpoints.GroupBy(static endpoint => endpoint.Name)
             .Where(static endpoint => endpoint.Count() is > 1)
             .Select(static endpoint => endpoint.Key)
             .OfType<string?>()
-            .FirstOrDefault() is string value)
+            .FirstOrDefault())
         {
-            builder.AddError(SR.FormatID2013(value));
+            case string value:
+                builder.AddError(SR.FormatID2013(value));
+                break;
+        }
+
+        foreach (var device in options.Devices)
+        {
+            switch (device.Name)
+            {
+                case string value when value.Contains('+', StringComparison.OrdinalIgnoreCase) ||
+                                       value.Contains('*', StringComparison.OrdinalIgnoreCase):
+                    builder.AddError(SR.FormatID2020(device.Name));
+                    break;
+            }
+
+            switch (device.GetBooleanSetting(OpenNettySettings.ActionValidation))
+            {
+                case not null when device.Definition.Protocol is not OpenNettyProtocol.Nitoo:
+                    builder.AddError(SR.GetResourceString(SR.ID2010));
+                    break;
+            }
         }
 
         foreach (var endpoint in options.Endpoints)
         {
-            if (!string.IsNullOrEmpty(endpoint.Name) &&
-                (endpoint.Name.Contains('+', StringComparison.OrdinalIgnoreCase) ||
-                 endpoint.Name.Contains('*', StringComparison.OrdinalIgnoreCase)))
+            switch (endpoint.Name)
             {
-                builder.AddError(SR.FormatID2000(endpoint.Name));
+                case string value when value.Contains('+', StringComparison.OrdinalIgnoreCase) ||
+                                       value.Contains('*', StringComparison.OrdinalIgnoreCase):
+                    builder.AddError(SR.FormatID2000(endpoint.Name));
+                    break;
             }
 
             switch (endpoint.GetBooleanSetting(OpenNettySettings.ActionValidation))
@@ -168,21 +198,21 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
                     builder.AddError(SR.FormatID2014(endpoint.Name));
                     break;
 
-                case string type when type is not (
+                case string value when value is not (
                     OpenNettySettings.FunctionTypes.AutomationActuator or
                     OpenNettySettings.FunctionTypes.LightActuator      or 
                     OpenNettySettings.FunctionTypes.ScheduledScenario  or
                     OpenNettySettings.FunctionTypes.ScheduledScenarioPlus):
-                    builder.AddError(SR.FormatID2003(endpoint.Name, type));
+                    builder.AddError(SR.FormatID2003(endpoint.Name, value));
                     break;
             }
 
             switch (endpoint.GetStringSetting(OpenNettySettings.SwitchMode))
             {
-                case string mode when mode is not (
+                case string value when value is not (
                     OpenNettySettings.SwitchModes.Default or
                     OpenNettySettings.SwitchModes.PushButton):
-                    builder.AddError(SR.FormatID2004(endpoint.Name, mode));
+                    builder.AddError(SR.FormatID2004(endpoint.Name, value));
                     break;
             }
 
@@ -192,14 +222,14 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
                     builder.AddError(SR.FormatID2015(endpoint.Name));
                     break;
 
-                case string numbers when numbers.Split(',', StringSplitOptions.RemoveEmptyEntries) is not [_, ..] array ||
+                case string value when value.Split(',', StringSplitOptions.RemoveEmptyEntries) is not [_, ..] array ||
                     array.Any(number => !byte.TryParse(number, CultureInfo.InvariantCulture, out _)):
                     builder.AddError(SR.FormatID2016(endpoint.Name));
                     break;
             }
 
             static bool SupportsLightControl(OpenNettyEndpoint endpoint) =>
-                endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchControl) ||
+                endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchControl)  ||
                 endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingControl) ||
                 endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingControl);
 

--- a/src/OpenNetty/OpenNettyDevice.cs
+++ b/src/OpenNetty/OpenNettyDevice.cs
@@ -37,15 +37,23 @@ public sealed class OpenNettyDevice : IEquatable<OpenNettyDevice>
     public OpenNettyGateway? Gateway { get; init; }
 
     /// <summary>
-    /// Gets or sets the unique identifier associated with the
-    /// device (typically, a serial number or a MAC address).
+    /// Gets or sets the unique identifier associated with the device,
+    /// if applicable (typically, a serial number or a MAC address).
     /// </summary>
-    public required OpenNettyDeviceIdentifier Identifier { get; init; }
+    /// <remarks>
+    /// Note: some devices may not have a unique identifier (e.g, legacy SCS devices).
+    /// </remarks>
+    public OpenNettyDeviceIdentifier? Identifier { get; init; }
 
     /// <summary>
     /// Gets or sets the identity associated with the device.
     /// </summary>
     public required OpenNettyDeviceIdentity Identity { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name associated with the device.
+    /// </summary>
+    public required string Name { get; init; }
 
     /// <summary>
     /// Gets or sets the user-defined settings associated with the device, if applicable.
@@ -111,6 +119,7 @@ public sealed class OpenNettyDevice : IEquatable<OpenNettyDevice>
             Gateway == other.Gateway &&
             Identifier == other.Identifier &&
             Identity == other.Identity &&
+            string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase) &&
             Settings.Count == other.Settings.Count && !Settings.Except(other.Settings).Any() &&
             Units.Length == other.Units.Length && !Units.Except(other.Units).Any();
     }
@@ -126,6 +135,7 @@ public sealed class OpenNettyDevice : IEquatable<OpenNettyDevice>
         hash.Add(Gateway);
         hash.Add(Identifier);
         hash.Add(Identity);
+        hash.Add(Name);
 
         hash.Add(Settings.Count);
         foreach (var (name, value) in Settings)
@@ -147,7 +157,7 @@ public sealed class OpenNettyDevice : IEquatable<OpenNettyDevice>
     /// Computes the <see cref="string"/> representation of the current device.
     /// </summary>
     /// <returns>The <see cref="string"/> representation of the current device.</returns>
-    public override string ToString() => Identifier.ToString();
+    public override string ToString() => Name ?? string.Empty;
 
     /// <summary>
     /// Determines whether two <see cref="OpenNettyDevice"/> instances are equal.

--- a/src/OpenNetty/OpenNettyDeviceDefinition.cs
+++ b/src/OpenNetty/OpenNettyDeviceDefinition.cs
@@ -5,6 +5,7 @@
  */
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenNetty;
 
@@ -107,6 +108,27 @@ public sealed class OpenNettyDeviceDefinition : IEquatable<OpenNettyDeviceDefini
     }
 
     /// <summary>
+    /// Resolves the identity corresponding to the specified brand and model.
+    /// </summary>
+    /// <param name="brand">The device brand.</param>
+    /// <param name="model">The device model.</param>
+    /// <returns>The resolved identity.</returns>
+    public OpenNettyDeviceIdentity GetIdentity(OpenNettyBrand brand, string model)
+        => TryGetIdentity(brand, model, out OpenNettyDeviceIdentity? identity)
+            ? identity.Value
+            : throw new InvalidOperationException(SR.GetResourceString(SR.ID0127));
+
+    /// <summary>
+    /// Resolves the unit corresponding to the specified identifier.
+    /// </summary>
+    /// <param name="identifier">The unit identifier.</param>
+    /// <returns>The definition of the resolved unit.</returns>
+    public OpenNettyUnitDefinition GetUnitDefinition(byte identifier)
+        => TryGetUnitDefinition(identifier, out OpenNettyUnitDefinition? unit)
+            ? unit
+            : throw new InvalidOperationException(SR.FormatID0087(identifier));
+
+    /// <summary>
     /// Determines whether the device has the specified capability.
     /// </summary>
     /// <param name="capability">The capability name.</param>
@@ -133,14 +155,71 @@ public sealed class OpenNettyDeviceDefinition : IEquatable<OpenNettyDeviceDefini
 
         ArgumentException.ThrowIfNullOrEmpty(model);
 
-        foreach (var identity in Identities)
+        for (var index = 0; index < Identities.Length; index++)
         {
-            if (identity.Brand == brand && string.Equals(identity.Model, model, StringComparison.OrdinalIgnoreCase))
+            if (Identities[index].Brand == brand &&
+                string.Equals(Identities[index].Model, model, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
         }
 
+        return false;
+    }
+
+    /// <summary>
+    /// Tries to resolve the identity corresponding to the specified brand and model.
+    /// </summary>
+    /// <param name="brand">The device brand.</param>
+    /// <param name="model">The device model.</param>
+    /// <param name="identity">The resolved identity if found, <see langword="null"/> otherwise.</param>
+    /// <returns>
+    /// <see langword="true"/> if the device has an identity matching the
+    /// specified brand and model, <see langword="false"/> otherwise.
+    /// </returns>
+    public bool TryGetIdentity(OpenNettyBrand brand, string model, [NotNullWhen(true)] out OpenNettyDeviceIdentity? identity)
+    {
+        if (!Enum.IsDefined(brand))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0006), nameof(brand));
+        }
+
+        ArgumentException.ThrowIfNullOrEmpty(model);
+
+        for (var index = 0; index < Identities.Length; index++)
+        {
+            if (Identities[index].Brand == brand &&
+                string.Equals(Identities[index].Model, model, StringComparison.OrdinalIgnoreCase))
+            {
+                identity = Identities[index];
+                return true;
+            }
+        }
+
+        identity = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Tries to resolve the unit corresponding to the specified identifier.
+    /// </summary>
+    /// <param name="identifier">The unit identifier.</param>
+    /// <param name="definition">The definition of the resolved unit if found, <see langword="null"/> otherwise.</param>
+    /// <returns>
+    /// <see langword="true"/> if the device has a unit matching the specified identifier, <see langword="false"/> otherwise.
+    /// </returns>
+    public bool TryGetUnitDefinition(byte identifier, [NotNullWhen(true)] out OpenNettyUnitDefinition? definition)
+    {
+        for (var index = 0; index < Units.Length; index++)
+        {
+            if (Units[index].Id == identifier)
+            {
+                definition = Units[index];
+                return true;
+            }
+        }
+
+        definition = null;
         return false;
     }
 

--- a/src/OpenNetty/OpenNettyDeviceIdentifier.cs
+++ b/src/OpenNetty/OpenNettyDeviceIdentifier.cs
@@ -182,7 +182,7 @@ public readonly struct OpenNettyDeviceIdentifier : IEquatable<OpenNettyDeviceIde
         else if (identifier.Type is OpenNettyDeviceIdentifierType.ScsSerialNumber or
                                     OpenNettyDeviceIdentifierType.ZigbeeSerialNumber)
         {
-            return $"00:04:74:00:{identifier.Value}";
+            return $"00:04:74:00:{string.Join(":", Enumerable.Range(0, 4).Select(index => identifier.Value.Substring(index * 2, 2)))}";
         }
 
         throw new ArgumentException(SR.GetResourceString(SR.ID0110), nameof(identifier));
@@ -222,7 +222,7 @@ public readonly struct OpenNettyDeviceIdentifier : IEquatable<OpenNettyDeviceIde
                 throw new ArgumentException(SR.GetResourceString(SR.ID0112), nameof(identifier));
             }
 
-            return identifier.Value["00:04:74:00:".Length..];
+            return identifier.Value["00:04:74:00:".Length..].Replace(":", "");
         }
 
         throw new ArgumentException(SR.GetResourceString(SR.ID0112), nameof(identifier));
@@ -247,7 +247,7 @@ public readonly struct OpenNettyDeviceIdentifier : IEquatable<OpenNettyDeviceIde
                 throw new ArgumentException(SR.GetResourceString(SR.ID0113), nameof(identifier));
             }
 
-            return identifier.Value["00:04:74:00:".Length..];
+            return identifier.Value["00:04:74:00:".Length..].Replace(":", "");
         }
 
         throw new ArgumentException(SR.GetResourceString(SR.ID0113), nameof(identifier));

--- a/src/OpenNetty/OpenNettyDevices.cs
+++ b/src/OpenNetty/OpenNettyDevices.cs
@@ -5,6 +5,7 @@
  */
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Xml.Linq;
@@ -29,45 +30,26 @@ public static class OpenNettyDevices
     /// <see langword="null"/> if the device definition couldn't be found in the database.
     /// </returns>
     /// <exception cref="ArgumentException">The model is null or empty or the brand is not valid.</exception>
-    public static OpenNettyDeviceDefinition? GetDeviceByModel(OpenNettyBrand brand, string model)
-    {
-        ArgumentException.ThrowIfNullOrEmpty(model);
-
-        if (!Enum.IsDefined(brand))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0006), nameof(brand));
-        }
-
-        foreach (var device in _devices.Value)
-        {
-            foreach (var identity in device.Identities)
-            {
-                if (identity.Brand == brand && string.Equals(identity.Model, model, StringComparison.OrdinalIgnoreCase))
-                {
-                    return device;
-                }
-            }
-        }
-
-        return null;
-    }
+    public static OpenNettyDeviceDefinition GetDeviceDefinitionByModel(OpenNettyBrand brand, string model)
+        => TryGetDeviceDefinitionByModel(brand, model, out OpenNettyDeviceDefinition? definition)
+            ? definition
+            : throw new InvalidOperationException(SR.FormatID0085(brand, model));
 
     /// <summary>
-    /// Resolves the unit definition corresponding to the specified brand, model and unit identifier.
+    /// Resolves the device definition corresponding to the specified brand and model.
     /// </summary>
     /// <param name="brand">The device brand.</param>
     /// <param name="model">The device model.</param>
-    /// <param name="id">The unit identifier.</param>
+    /// <param name="definition">The device definition.</param>
     /// <returns>
-    /// The unit definition corresponding to the specified brand, model and unit identifier or
-    /// <see langword="null"/> if the unit definition couldn't be found in the database.
+    /// <see langword="true"/> if the device definition corresponding to the
+    /// specified brand and model was found; otherwise, <see langword="false"/>.
     /// </returns>
     /// <exception cref="ArgumentException">The model is null or empty or the brand is not valid.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">The unit identifier is out of range.</exception>
-    public static OpenNettyUnitDefinition? GetUnitByModel(OpenNettyBrand brand, string model, byte id)
+    public static bool TryGetDeviceDefinitionByModel(OpenNettyBrand brand,
+        string model, [NotNullWhen(true)] out OpenNettyDeviceDefinition? definition)
     {
         ArgumentException.ThrowIfNullOrEmpty(model);
-        ArgumentOutOfRangeException.ThrowIfZero(id);
 
         if (!Enum.IsDefined(brand))
         {
@@ -80,18 +62,14 @@ public static class OpenNettyDevices
             {
                 if (identity.Brand == brand && string.Equals(identity.Model, model, StringComparison.OrdinalIgnoreCase))
                 {
-                    foreach (var unit in device.Units)
-                    {
-                        if (unit.Id == id)
-                        {
-                            return unit;
-                        }
-                    }
+                    definition = device;
+                    return true;
                 }
             }
         }
 
-        return null;
+        definition = null;
+        return false;
     }
 
     private static ImmutableArray<OpenNettyDeviceDefinition> CreateDeviceDefinitions()

--- a/src/OpenNetty/OpenNettyGateway.cs
+++ b/src/OpenNetty/OpenNettyGateway.cs
@@ -196,14 +196,14 @@ public sealed class OpenNettyGateway
         ArgumentException.ThrowIfNullOrEmpty(name);
         ArgumentException.ThrowIfNullOrEmpty(model);
 
-        var definition = OpenNettyDevices.GetDeviceByModel(brand, model)
-            ?? throw new InvalidOperationException(SR.FormatID0085(brand, model));
+        var definition = OpenNettyDevices.GetDeviceDefinitionByModel(brand, model);
 
         var device = new OpenNettyDevice
         {
             Definition = definition,
             Identifier = identifier,
-            Identity = definition.Identities.Single(identity => identity.Brand == brand && identity.Model == model)
+            Identity = definition.GetIdentity(brand, model),
+            Name = name
         };
 
         return Create(name, device, endpoint, password, options);
@@ -231,14 +231,14 @@ public sealed class OpenNettyGateway
         ArgumentException.ThrowIfNullOrEmpty(name);
         ArgumentException.ThrowIfNullOrEmpty(model);
 
-        var definition = OpenNettyDevices.GetDeviceByModel(brand, model)
-            ?? throw new InvalidOperationException(SR.FormatID0085(brand, model));
+        var definition = OpenNettyDevices.GetDeviceDefinitionByModel(brand, model);
 
         var device = new OpenNettyDevice
         {
             Definition = definition,
             Identifier = identifier,
-            Identity = definition.Identities.Single(identity => identity.Brand == brand && identity.Model == model)
+            Identity = definition.GetIdentity(brand, model),
+            Name = name
         };
 
         return Create(name, device, port, options);

--- a/src/OpenNetty/OpenNettyManager.cs
+++ b/src/OpenNetty/OpenNettyManager.cs
@@ -72,6 +72,46 @@ public class OpenNettyManager
     }
 
     /// <summary>
+    /// Resolves a device using the specified name.
+    /// </summary>
+    /// <remarks>
+    /// Note: the name lookup is case-sensitive.
+    /// </remarks>
+    /// <param name="name">The device name.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation and whose result
+    /// contains the resolved device, or <see langword="null"/> if no matching device could be resolved.
+    /// </returns>
+    public virtual ValueTask<OpenNettyDevice?> FindDeviceByNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        OpenNettyDevice? device = null;
+
+        for (var index = 0; index < _options.CurrentValue.Devices.Count; index++)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return ValueTask.FromCanceled<OpenNettyDevice?>(cancellationToken);
+            }
+
+            if (string.Equals(_options.CurrentValue.Devices[index].Name, name, StringComparison.Ordinal))
+            {
+                if (device is not null)
+                {
+                    return ValueTask.FromException<OpenNettyDevice?>(
+                        new InvalidOperationException(SR.GetResourceString(SR.ID0126)));
+                }
+
+                device = _options.CurrentValue.Devices[index];
+            }
+        }
+
+        return ValueTask.FromResult(device);
+    }
+
+    /// <summary>
     /// Resolves an endpoint using the specified name.
     /// </summary>
     /// <remarks>

--- a/src/OpenNetty/OpenNettyResources.resx
+++ b/src/OpenNetty/OpenNettyResources.resx
@@ -376,7 +376,7 @@
     <value>A non-null '{0}' attribute is required for endpoint, device or unit settings.</value>
   </data>
   <data name="ID0087" xml:space="preserve">
-    <value>The unit '{0}' is not valid for the device {1} '{2}'.</value>
+    <value>The unit '{0}' is not valid for this device.</value>
   </data>
   <data name="ID0088" xml:space="preserve">
     <value>A non-null '{0}' attribute is required for Nitoo scenarios.</value>
@@ -439,7 +439,7 @@
     <value>Gateway devices must declare a '{0}' node with the gateway details.</value>
   </data>
   <data name="ID0108" xml:space="preserve">
-    <value>Device nodes must include a '{0}' or '{1}' attribute.</value>
+    <value>Device nodes must include a '{0}' attribute when the '{1}' or '{2}' attributes are not specified.</value>
   </data>
   <data name="ID0109" xml:space="preserve">
     <value>The specified MAC address contains invalid characters or uses an invalid format.</value>
@@ -493,7 +493,10 @@
     <value>No configuration file was found. For the OpenNetty daemon to work correctly, a configuration file named '{0}' must be present in the application directory. Alternatively, one or more configuration files ending with '{1}' can be placed in the '{2}' directory.</value>
   </data>
   <data name="ID0126" xml:space="preserve">
-    <value>At least one OpenWebNet gateway must be configured.</value>
+    <value>Multiple endpoints matching the specified criteria were found.</value>
+  </data>
+  <data name="ID0127" xml:space="preserve">
+    <value>The specified identity is not valid for this device.</value>
   </data>
   <data name="ID2000" xml:space="preserve">
     <value>The endpoint name '{0}' is not valid. Endpoint names cannot contain the '+' or '*' characters.</value>
@@ -545,6 +548,18 @@
   </data>
   <data name="ID2016" xml:space="preserve">
     <value>The endpoint '{0}' has an invalid list of push button numbers attached.</value>
+  </data>
+  <data name="ID2017" xml:space="preserve">
+    <value>At least one OpenWebNet gateway must be configured.</value>
+  </data>
+  <data name="ID2018" xml:space="preserve">
+    <value>The Home Assistant object identifier '{0}' is not fvalid: object identifiers can only contain ASCII letters, digits, underscores, and hyphens.</value>
+  </data>
+  <data name="ID2019" xml:space="preserve">
+    <value>Multiple devices with the name '{0}' have been added.</value>
+  </data>
+  <data name="ID2020" xml:space="preserve">
+    <value>The device name '{0}' is not valid. Device names cannot contain the '+' or '*' characters.</value>
   </data>
   <data name="ID6000" xml:space="preserve">
     <value>The OpenNetty hosted service is starting.</value>

--- a/src/OpenNetty/OpenNettySettings.cs
+++ b/src/OpenNetty/OpenNettySettings.cs
@@ -77,6 +77,11 @@ public static class OpenNettySettings
     public static readonly OpenNettySetting HomeAssistantLightName = new("Home Assistant light name");
 
     /// <summary>
+    /// Home Assistant object ID.
+    /// </summary>
+    public static readonly OpenNettySetting HomeAssistantObjectId = new("Home Assistant object ID");
+
+    /// <summary>
     /// Home Assistant scenario device class.
     /// </summary>
     public static readonly OpenNettySetting HomeAssistantScenarioDeviceClass = new("Home Assistant scenario device class");

--- a/src/OpenNetty/OpenNettyUtilities.cs
+++ b/src/OpenNetty/OpenNettyUtilities.cs
@@ -1,0 +1,98 @@
+﻿using System.Text;
+
+namespace OpenNetty;
+
+/// <summary>
+/// Exposes internal utilities used by the OpenNetty components.
+/// </summary>
+internal static class OpenNettyUtilities
+{
+    /// <summary>
+    /// Computes the default endpoint name for a given combination of protocol, address, device and unit.
+    /// </summary>
+    /// <param name="protocol">The protocol.</param>
+    /// <param name="address">The address.</param>
+    /// <param name="device">The device.</param>
+    /// <param name="unit">The unit.</param>
+    /// <returns>The default endpoint name.</returns>
+    public static string ComputeDefaultEndpointName(
+        OpenNettyProtocol protocol, OpenNettyAddress? address, OpenNettyDevice? device, OpenNettyUnit? unit)
+    {
+        if (!Enum.IsDefined(protocol))
+        {
+            throw new InvalidOperationException(SR.GetResourceString(SR.ID0057));
+        }
+
+        var builder = new StringBuilder(Enum.GetName(protocol));
+        builder.Append('/');
+
+        switch (protocol)
+        {
+            case OpenNettyProtocol.Scs when address?.Type is OpenNettyAddressType.ScsLightPoint:
+                var (extension, general, group, area, point) = OpenNettyAddress.ToScsLightPointAddress(address.Value);
+
+                if (OpenNettyAddress.IsScsLightPointAreaAddress(address.Value))
+                {
+                    builder.Append("PL area");
+                    builder.Append('/');
+                    builder.Append(extension);
+                    builder.Append('/');
+                    builder.Append(area);
+                }
+
+                else if (OpenNettyAddress.IsScsLightPointGeneralAddress(address.Value))
+                {
+                    builder.Append("PL general");
+                    builder.Append('/');
+                    builder.Append(extension);
+                }
+
+                else if (OpenNettyAddress.IsScsLightPointGroupAddress(address.Value))
+                {
+                    builder.Append("PL group");
+                    builder.Append('/');
+                    builder.Append(extension);
+                    builder.Append('/');
+                    builder.Append(group);
+                }
+
+                else if (OpenNettyAddress.IsScsLightPointPointToPointAddress(address.Value))
+                {
+                    builder.Append("PL point-to-point");
+                    builder.Append('/');
+                    builder.Append(extension);
+                    builder.Append('/');
+                    builder.Append(area);
+                    builder.Append('/');
+                    builder.Append(point);
+                }
+
+                builder.Append(address.Value.ToString());
+                break;
+
+            case OpenNettyProtocol.Scs when address?.Type is OpenNettyAddressType.ScsScenarioPlus:
+                builder.Append("PL scenario plus");
+                builder.Append('/');
+                builder.Append(OpenNettyAddress.ToScsScenarioPlusAddress(address.Value));
+                break;
+
+            case OpenNettyProtocol.Nitoo or OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee:
+                if (device?.Identifier is null)
+                {
+                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0104));
+                }
+
+                builder.Append(device.Identifier.Value);
+
+                if (unit is not null)
+                {
+                    builder.Append('/');
+                    builder.Append(unit.Definition.Id);
+                }
+                break;
+
+        }
+
+        return builder.ToString();
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/opennetty/opennetty-core/issues/117.

Note: this PR changes how HA object IDs are computed so users using the new bits are encouraged to flush the old/retained entries using MQTT Explorer.