### PR TITLE
Improve support for ID-less gateways

### DIFF
--- a/src/OpenNetty.Mqtt/OpenNettyMqttHostedService.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttHostedService.cs
@@ -62,7 +62,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
         return StableCompositeAsyncDisposable.Create(
         [
             await _events.ActionScenarioReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(async arguments =>
                 {
                     // Note: if the device class is "doorbell", a standard "ring" event is also sent for action scenarios.
@@ -103,7 +102,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.AvailabilityReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Availability, builder =>
                 {
                     builder.WithPayload(arguments.Availability switch
@@ -119,7 +117,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.BatteryAlertReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.BatteryAlert, builder =>
                 {
                     builder.WithPayload("ON");
@@ -129,7 +126,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.BatteryLevelReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.BatteryLevel, builder =>
                 {
                     builder.WithPayload(arguments.Level.ToString(CultureInfo.InvariantCulture));
@@ -139,7 +135,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.BrightnessReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Brightness, builder =>
                 {
                     builder.WithPayload(arguments.Level.ToString(CultureInfo.InvariantCulture));
@@ -149,7 +144,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.DeviceCommunicationReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.LastCommunicationDate, builder =>
                 {
                     builder.WithPayload(TimeProvider.System.GetUtcNow().ToString("o", CultureInfo.InvariantCulture));
@@ -159,7 +153,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.DimmingScenarioReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
                     var node = new JsonObject
@@ -175,7 +168,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.IncomingMessageReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.IncomingMessage, builder =>
                 {
                     var node = new JsonObject
@@ -206,7 +198,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.OnOffScenarioReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
                     var node = new JsonObject
@@ -227,7 +218,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.OutgoingMessageReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.OutgoingMessage, builder =>
                 {
                     var node = new JsonObject
@@ -258,7 +248,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.PilotWireDerogationModeReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.PilotWireDerogationMode, builder =>
                 {
                     builder.WithPayload(arguments.Mode switch
@@ -317,7 +306,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.PilotWireSetpointModeReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.PilotWireSetpointMode, builder =>
                 {
                     builder.WithPayload(arguments.Mode switch
@@ -337,7 +325,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.PilotWireShutdownModeReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.PilotWireShutdownMode, builder =>
                 {
                     builder.WithPayload(arguments.Active ? "ON" : "OFF");
@@ -347,7 +334,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.PressureScenarioReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(async arguments =>
                 {
                     // Note: if the device class is "doorbell", a standard "ring" event is also sent for short pressure scenarios.
@@ -394,7 +380,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.PressureScenarioPlusReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(async arguments =>
                 {
                     // Note: if the device class is "doorbell", a standard "ring" event is also sent for short pressure scenarios.
@@ -441,7 +426,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.ProgressiveScenarioReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
                     var node = new JsonObject
@@ -457,7 +441,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.ShutterPositionReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.ShutterPosition, builder =>
                 {
                     builder.WithPayload(arguments.Position.ToString(CultureInfo.InvariantCulture));
@@ -467,7 +450,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.ShutterStateReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.ShutterState, builder =>
                 {
                     builder.WithPayload(arguments.State switch
@@ -487,7 +469,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.SmartMeterPowerCutModeReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.SmartMeterPowerCutMode, builder =>
                 {
                     builder.WithPayload(arguments.Active ? "ON" : "OFF");
@@ -497,7 +478,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.SmartMeterRateTypeReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.SmartMeterRateType, builder =>
                 {
                     builder.WithPayload(arguments.Type switch
@@ -514,7 +494,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.StopUpDownScenarioReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
                     var node = new JsonObject
@@ -536,7 +515,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.SwitchStateReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.SwitchState, builder =>
                 {
                     builder.WithPayload(arguments.State is OpenNettyModels.Lighting.SwitchState.Off ? "OFF": "ON");
@@ -546,7 +524,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.TimedScenarioReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
                     var node = new JsonObject
@@ -562,7 +539,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.ToggleScenarioReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
                 {
                     var node = new JsonObject
@@ -577,7 +553,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.WaterHeaterSetpointModeReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.WaterHeaterSetpointMode, builder =>
                 {
                     builder.WithPayload(arguments.Mode switch
@@ -595,7 +570,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.WaterHeaterStateReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.WaterHeaterState, builder =>
                 {
                     builder.WithPayload(arguments.State switch
@@ -612,7 +586,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.WirelessBurglarAlarmStateReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.WirelessBurglarAlarmState, builder =>
                 {
                     builder.WithPayload(arguments.State switch
@@ -633,7 +606,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.ZigbeeBindingEventReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.ZigbeeBinding, builder =>
                 {
                     builder.WithPayload(arguments.Type switch
@@ -651,7 +623,6 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
             await _events.ZigbeeNetworkEventReported
-                .Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.ZigbeeNetwork, builder =>
                 {
                     builder.WithPayload(arguments.Type switch

--- a/src/OpenNetty/OpenNettyBuilder.cs
+++ b/src/OpenNetty/OpenNettyBuilder.cs
@@ -492,8 +492,8 @@ public sealed class OpenNettyBuilder
 
         static ImmutableDictionary<OpenNettySetting, string> GetSettings(XElement element) =>
             element.Elements("Setting").ToImmutableDictionary(
-                element => new OpenNettySetting((string?) element.Attribute("Name") ?? throw new InvalidOperationException(SR.FormatID0086("Name"))),
-                element => (string?) element.Attribute("Value") ?? throw new InvalidOperationException(SR.FormatID0086("Name")));
+                static element => new OpenNettySetting((string?) element.Attribute("Name") ?? throw new InvalidOperationException(SR.FormatID0086("Name"))),
+                static element => (string?) element.Attribute("Value") ?? throw new InvalidOperationException(SR.FormatID0086("Name")));
 
         static OpenNettyScenario GetScenario(XElement element) => new()
         {

--- a/src/OpenNetty/OpenNettyConfiguration.cs
+++ b/src/OpenNetty/OpenNettyConfiguration.cs
@@ -23,7 +23,7 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
 
         foreach (var device in options.Devices)
         {
-            if (device.Identifier is null)
+            if (device.Identifier is null && !device.HasCapability(OpenNettyCapabilities.OpenWebNetGateway))
             {
                 continue;
             }
@@ -33,11 +33,22 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
             {
                 var address = device.Definition.Protocol switch
                 {
-                    OpenNettyProtocol.Nitoo  => OpenNettyAddress.FromNitooAddress(device.Identifier.Value,  unit: 0),
-                    OpenNettyProtocol.Zigbee => OpenNettyAddress.FromZigbeeAddress(device.Identifier.Value, unit: 0),
+                    OpenNettyProtocol.Nitoo  when device.HasCapability(OpenNettyCapabilities.OpenWebNetGateway) => null,
+                    OpenNettyProtocol.Zigbee when device.HasCapability(OpenNettyCapabilities.OpenWebNetGateway) => null,
+
+                    OpenNettyProtocol.Nitoo  when device.Identifier is OpenNettyDeviceIdentifier identifier
+                        => OpenNettyAddress.FromNitooAddress(identifier, unit: 0),
+
+                    OpenNettyProtocol.Zigbee when device.Identifier is OpenNettyDeviceIdentifier identifier
+                        => OpenNettyAddress.FromZigbeeAddress(identifier, unit: 0),
 
                     _ => null as OpenNettyAddress?
                 };
+
+                if (address is null && !device.HasCapability(OpenNettyCapabilities.OpenWebNetGateway))
+                {
+                    continue;
+                }
 
                 options.Endpoints.Add(new OpenNettyEndpoint
                 {
@@ -66,11 +77,22 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
 
                     var address = device.Definition.Protocol switch
                     {
-                        OpenNettyProtocol.Nitoo  => OpenNettyAddress.FromNitooAddress(device.Identifier.Value,  unit: definition.Id),
-                        OpenNettyProtocol.Zigbee => OpenNettyAddress.FromZigbeeAddress(device.Identifier.Value, unit: definition.Id),
+                        OpenNettyProtocol.Nitoo  when device.HasCapability(OpenNettyCapabilities.OpenWebNetGateway) => null,
+                        OpenNettyProtocol.Zigbee when device.HasCapability(OpenNettyCapabilities.OpenWebNetGateway) => null,
+
+                        OpenNettyProtocol.Nitoo  when device.Identifier is OpenNettyDeviceIdentifier identifier
+                            => OpenNettyAddress.FromNitooAddress(identifier, unit: definition.Id),
+
+                        OpenNettyProtocol.Zigbee when device.Identifier is OpenNettyDeviceIdentifier identifier
+                            => OpenNettyAddress.FromZigbeeAddress(identifier, unit: definition.Id),
 
                         _ => null as OpenNettyAddress?
                     };
+
+                    if (address is null && !device.HasCapability(OpenNettyCapabilities.OpenWebNetGateway))
+                    {
+                        continue;
+                    }
 
                     var unit = device.Units.SingleOrDefault(unit => unit.Definition == definition) ?? new OpenNettyUnit
                     {

--- a/src/OpenNetty/OpenNettyCoordinator.cs
+++ b/src/OpenNetty/OpenNettyCoordinator.cs
@@ -1650,7 +1650,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                 if (endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingState) ||
                     endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState))
                 {
-                    tasks.Add(_controller.GetBrightnessAsync(endpoint, cancellationToken).AsTask());
+                    tasks.Add(_controller.EnumerateBrightnessAsync(endpoint, cancellationToken).ToListAsync(cancellationToken).AsTask());
                 }
 
                 if (endpoint is { Protocol: OpenNettyProtocol.Nitoo, Unit.Definition.AssociatedUnitId: byte unit })
@@ -1665,7 +1665,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                                   endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState));
 
                     tasks.Add(Parallel.ForEachAsync(endpoints, cancellationToken, async (endpoint, cancellationToken) =>
-                        await _controller.GetBrightnessAsync(endpoint, cancellationToken)));
+                        await _controller.EnumerateBrightnessAsync(endpoint, cancellationToken).ToListAsync(cancellationToken)));
                 }
 
                 if (message.Protocol  is OpenNettyProtocol.Nitoo                 &&
@@ -1683,7 +1683,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                                                   endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingState));
 
                     tasks.Add(Parallel.ForEachAsync(endpoints, cancellationToken, async (endpoint, cancellationToken) =>
-                        await _controller.GetBrightnessAsync(endpoint, cancellationToken)));
+                        await _controller.EnumerateBrightnessAsync(endpoint, cancellationToken).ToListAsync(cancellationToken)));
                 }
 
                 await Task.WhenAll(tasks);

--- a/src/OpenNetty/OpenNettyResources.resx
+++ b/src/OpenNetty/OpenNettyResources.resx
@@ -427,7 +427,7 @@
     <value>Multiple gateways matching the specified criteria were found.</value>
   </data>
   <data name="ID0104" xml:space="preserve">
-    <value>A serial number attribute must be attached to device nodes.</value>
+    <value>A serial number or a unique name must be attached to device nodes.</value>
   </data>
   <data name="ID0105" xml:space="preserve">
     <value>An endpoint name must be explicitly attached to SCS light point endpoints.</value>

--- a/src/OpenNetty/OpenNettySession.cs
+++ b/src/OpenNetty/OpenNettySession.cs
@@ -439,14 +439,14 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
                             ClientNonce: RandomNumberGenerator.GetBytes(algorithm.HashSize / 8));
 
                         // Compute the hash of the OPEN password and convert it to its lowercase hexadecimal representation.
-                        var password = Convert.ToHexString(algorithm.ComputeHash(Encoding.UTF8.GetBytes(gateway.Password))).ToLowerInvariant();
+                        var password = Convert.ToHexStringLower(algorithm.ComputeHash(Encoding.UTF8.GetBytes(gateway.Password)));
 
                         // Compute and send the digest used to authenticate the client.
                         await connection.SendAsync(new OpenNettyFrame(
                             new OpenNettyField(OpenNettyParameter.Empty, new OpenNettyParameter(ConvertToDigits(parameters.ClientNonce))),
                             new OpenNettyField(new OpenNettyParameter(ConvertToDigits(algorithm.ComputeHash(Encoding.UTF8.GetBytes(new StringBuilder()
                                 .Append(parameters.ServerNonce)
-                                .Append(Convert.ToHexString(parameters.ClientNonce).ToLowerInvariant())
+                                .Append(Convert.ToHexStringLower(parameters.ClientNonce))
                                 .Append("736F70653E")
                                 .Append("636F70653E")
                                 .Append(password)
@@ -464,7 +464,7 @@ public sealed class OpenNettySession : IConnectableAsyncObservable<OpenNettyMess
                                     left : MemoryMarshal.AsBytes<char>(digest),
                                     right: MemoryMarshal.AsBytes<char>(ConvertToDigits(algorithm.ComputeHash(Encoding.UTF8.GetBytes(new StringBuilder()
                                         .Append(parameters.ServerNonce)
-                                        .Append(Convert.ToHexString(parameters.ClientNonce).ToLowerInvariant())
+                                        .Append(Convert.ToHexStringLower(parameters.ClientNonce))
                                         .Append(password)
                                         .ToString()))))):
                                 // Acknowledge the negotiated authentication data.

--- a/src/OpenNetty/OpenNettyUtilities.cs
+++ b/src/OpenNetty/OpenNettyUtilities.cs
@@ -77,17 +77,31 @@ internal static class OpenNettyUtilities
                 break;
 
             case OpenNettyProtocol.Nitoo or OpenNettyProtocol.Scs or OpenNettyProtocol.Zigbee:
-                if (device?.Identifier is null)
+                if (device?.Identifier is OpenNettyDeviceIdentifier identifier)
                 {
-                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0104));
+                    builder.Append(identifier.ToString());
+
+                    if (unit is not null)
+                    {
+                        builder.Append('/');
+                        builder.Append(unit.Definition.Id);
+                    }
                 }
 
-                builder.Append(device.Identifier.Value);
-
-                if (unit is not null)
+                else if (!string.IsNullOrEmpty(device?.Name))
                 {
-                    builder.Append('/');
-                    builder.Append(unit.Definition.Id);
+                    builder.Append(device.Name);
+
+                    if (unit is not null)
+                    {
+                        builder.Append('/');
+                        builder.Append(unit.Definition.Id);
+                    }
+                }
+
+                else
+                {
+                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0104));
                 }
                 break;
 


### PR DESCRIPTION
This PR also removes the unnecessary `.Where(static arguments => !string.IsNullOrEmpty(arguments.Endpoint.Name))` observable filters, as an endpoint cannot have a null name.