### PR TITLE
Support SCS dry contact endpoints (WHO=25) and address a few existing issues

### DIFF
--- a/src/OpenNetty.Mqtt/OpenNettyMqttAttributes.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttAttributes.cs
@@ -32,6 +32,11 @@ public static class OpenNettyMqttAttributes
     public const string Brightness = "brightness";
 
     /// <summary>
+    /// Dry contact state.
+    /// </summary>
+    public const string DryContactState = "dry_contact_state";
+
+    /// <summary>
     /// Firmware version.
     /// </summary>
     public const string FirmwareVersion = "firmware_version";

--- a/src/OpenNetty.Mqtt/OpenNettyMqttHostedService.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttHostedService.cs
@@ -167,6 +167,55 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                 .Retry()
                 .SubscribeAsync(static arguments => ValueTask.CompletedTask),
 
+            await _events.DryContactScenarioReported
+                .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.Scenario, builder =>
+                {
+                    var node = new JsonObject
+                    {
+                        ["event_type"] = arguments.Type switch
+                        {
+                            OpenNettyModels.ScenariosPlus.DryContactScenarioType.Closed => "contact_closed",
+                            OpenNettyModels.ScenariosPlus.DryContactScenarioType.Open   => "contact_open",
+
+                            _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0068))
+                        }
+                    };
+
+                    builder.WithContentType(MediaTypeNames.Application.Json);
+                    builder.WithPayload(node.ToJsonString());
+                }))
+                .Retry()
+                .SubscribeAsync(static arguments => ValueTask.CompletedTask),
+
+            await _events.DryContactStateReported
+                .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.DryContactState, builder =>
+                {
+                    var node = new JsonObject
+                    {
+                        ["state"] = arguments.State switch
+                        {
+                            OpenNettyModels.ScenariosPlus.DryContactState.Closed => "closed",
+                            OpenNettyModels.ScenariosPlus.DryContactState.Open   => "open",
+
+                            _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0068))
+                        },
+
+                        ["origin"] = arguments.Origin switch
+                        {
+                            OpenNettyModels.ScenariosPlus.DryContactStateOrigin.StateRequest => "state_request",
+                            OpenNettyModels.ScenariosPlus.DryContactStateOrigin.SystemEvent  => "system_event",
+
+                            _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0068))
+                        }
+                    };
+
+                    builder.WithContentType(MediaTypeNames.Application.Json);
+                    builder.WithPayload(node.ToJsonString());
+                    builder.WithRetainFlag();
+                }))
+                .Retry()
+                .SubscribeAsync(static arguments => ValueTask.CompletedTask),
+
             await _events.IncomingMessageReported
                 .Do(arguments => ReportAsync(arguments.Endpoint, OpenNettyMqttAttributes.IncomingMessage, builder =>
                 {
@@ -612,7 +661,7 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                     {
                         OpenNettyModels.ScenariosPlus.ZigbeeBindingEventType.Closed   => "closed",
                         OpenNettyModels.ScenariosPlus.ZigbeeBindingEventType.Canceled => "canceled",
-                        OpenNettyModels.ScenariosPlus.ZigbeeBindingEventType.Opened   => "opened",
+                        OpenNettyModels.ScenariosPlus.ZigbeeBindingEventType.Open     => "open",
 
                         _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0068))
                     });
@@ -631,7 +680,7 @@ public sealed class OpenNettyMqttHostedService : BackgroundService, IOpenNettyHa
                         OpenNettyModels.Management.ZigbeeNetworkEventType.Created => "created",
                         OpenNettyModels.Management.ZigbeeNetworkEventType.Joined  => "joined",
                         OpenNettyModels.Management.ZigbeeNetworkEventType.Left    => "left",
-                        OpenNettyModels.Management.ZigbeeNetworkEventType.Opened  => "opened",
+                        OpenNettyModels.Management.ZigbeeNetworkEventType.Open    => "open",
 
                         _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0068))
                     });

--- a/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
+++ b/src/OpenNetty.Mqtt/OpenNettyMqttWorker.cs
@@ -225,6 +225,13 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     break;
                 }
 
+                case OpenNettyMqttAttributes.DryContactState when operation is OpenNettyMqttOperation.Get:
+                {
+                    // Note: the response to this request is monitored by the hosted service and doesn't need to be reported here.
+                    _ = await _controller.GetDryContactStateAsync(endpoint, cancellationToken);
+                    break;
+                }
+
                 case OpenNettyMqttAttributes.FirmwareVersion when operation is OpenNettyMqttOperation.Get:
                 {
                     var version = await _controller.GetFirmwareVersionAsync(endpoint, cancellationToken);
@@ -447,6 +454,16 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                                 (short?) parameters?["dimming_step"] ?? throw new InvalidDataException(SR.GetResourceString(SR.ID0068)), cancellationToken);
                             break;
                         }
+
+                        case "contact_open":
+                            await _controller.DispatchDryContactScenarioAsync(endpoint,
+                                OpenNettyModels.ScenariosPlus.DryContactScenarioType.Open, cancellationToken);
+                            break;
+
+                        case "contact_closed":
+                            await _controller.DispatchDryContactScenarioAsync(endpoint,
+                                OpenNettyModels.ScenariosPlus.DryContactScenarioType.Closed, cancellationToken);
+                            break;
 
                         case "end_of_extended_pressure":
                             await _controller.DispatchPressureScenarioPlusAsync(endpoint,
@@ -1225,6 +1242,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
 
             if (endpoint.HasCapability(OpenNettyCapabilities.ActionScenarioEvent)       ||
                 endpoint.HasCapability(OpenNettyCapabilities.DimmingScenarioEvent)      ||
+                endpoint.HasCapability(OpenNettyCapabilities.DryContactScenarioEvent)   ||
                 endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioEvent)        ||
                 endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioEvent)     ||
                 endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioPlusEvent) ||
@@ -1252,13 +1270,23 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     types.Add("dimming");
                 }
 
+                if (endpoint.HasCapability(OpenNettyCapabilities.DryContactScenarioEvent) &&
+                    endpoint.GetStringSetting(OpenNettySettings.FunctionType) is null or
+                        OpenNettySettings.FunctionTypes.ContactState)
+                {
+                    types.Add("contact_open");
+                    types.Add("contact_closed");
+                }
+
                 if (endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioEvent))
                 {
                     types.Add("switch_on");
                     types.Add("switch_off");
                 }
 
-                if (endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioEvent))
+                if (endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioEvent) &&
+                    endpoint.GetStringSetting(OpenNettySettings.FunctionType)
+                        is null or OpenNettySettings.FunctionTypes.ScheduledScenario)
                 {
                     if (endpoint.GetStringSetting(OpenNettySettings.HomeAssistantScenarioDeviceClass)
                         is OpenNettySettings.HomeAssistantDeviceClasses.Events.Doorbell)
@@ -1272,7 +1300,9 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     types.Add("extended_pressure");
                 }
 
-                if (endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioPlusEvent))
+                if (endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioPlusEvent) &&
+                    endpoint.GetStringSetting(OpenNettySettings.FunctionType)
+                        is null or OpenNettySettings.FunctionTypes.ScheduledScenarioPlus)
                 {
                     if (endpoint.GetStringSetting(OpenNettySettings.HomeAssistantScenarioDeviceClass)
                         is OpenNettySettings.HomeAssistantDeviceClasses.Events.Doorbell)
@@ -1320,6 +1350,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                         count   : endpoints.Count(static endpoint =>
                             endpoint.HasCapability(OpenNettyCapabilities.ActionScenarioEvent)       ||
                             endpoint.HasCapability(OpenNettyCapabilities.DimmingScenarioEvent)      ||
+                            endpoint.HasCapability(OpenNettyCapabilities.DryContactScenarioEvent)   ||
                             endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioEvent)        ||
                             endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioEvent)     ||
                             endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioPlusEvent) ||
@@ -1410,6 +1441,86 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                 };
             }
 
+            if (endpoint.HasCapability(OpenNettyCapabilities.DryContactScenarioActivation) &&
+                endpoint.GetStringSetting(OpenNettySettings.FunctionType) is null or OpenNettySettings.FunctionTypes.ContactState)
+            {
+                yield return new JsonObject
+                {
+                    ["platform"] = "button",
+                    ["unique_id"] = ComputeEntityUniqueId(endpoint, "91510f47-559b-4a44-a4d2-a0f4d3a634c6"u8),
+                    ["name"] = ComputeEntityDisplayName(
+                        name    : GetLocalizedString(SR.ID8125, culture),
+                        endpoint: endpoint,
+                        culture : culture,
+                        count   : endpoints.Count(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioActivation))),
+                    ["availability_topic"] = $"{topic}/{OpenNettyMqttAttributes.Availability}",
+                    ["command_topic"] = $"{topic}/{OpenNettyMqttAttributes.Scenario}/set",
+                    ["payload_press"] = new JsonObject { ["event_type"] = "contact_open" }.ToJsonString()
+                };
+
+                yield return new JsonObject
+                {
+                    ["platform"] = "button",
+                    ["unique_id"] = ComputeEntityUniqueId(endpoint, "e1b494f8-ab8b-4635-8f2c-81d354bc83dc"u8),
+                    ["name"] = ComputeEntityDisplayName(
+                        name    : GetLocalizedString(SR.ID8126, culture),
+                        endpoint: endpoint,
+                        culture : culture,
+                        count   : endpoints.Count(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.DryContactScenarioActivation))),
+                    ["availability_topic"] = $"{topic}/{OpenNettyMqttAttributes.Availability}",
+                    ["command_topic"] = $"{topic}/{OpenNettyMqttAttributes.Scenario}/set",
+                    ["payload_press"] = new JsonObject { ["event_type"] = "contact_closed" }.ToJsonString()
+                };
+            }
+
+            if (endpoint.HasCapability(OpenNettyCapabilities.DryContactState) &&
+                endpoint.GetStringSetting(OpenNettySettings.FunctionType) is null or OpenNettySettings.FunctionTypes.ContactState)
+            {
+                var component = new JsonObject
+                {
+                    ["platform"] = "binary_sensor",
+                    ["unique_id"] = ComputeEntityUniqueId(endpoint, "1aca2cbc-16cb-46df-be3a-ac6a2684910b"u8),
+                    ["name"] = ComputeEntityDisplayName(
+                        name    : GetLocalizedString(SR.ID8127, culture),
+                        endpoint: endpoint,
+                        culture : culture,
+                        count   : endpoints.Count(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.DryContactState))),
+                    ["availability_topic"] = $"{topic}/{OpenNettyMqttAttributes.Availability}",
+                    ["state_topic"] = $"{topic}/{OpenNettyMqttAttributes.DryContactState}",
+                    ["json_attributes_topic"] = $"{topic}/{OpenNettyMqttAttributes.DryContactState}",
+                    ["payload_on"] = "closed",
+                    ["payload_off"] = "open",
+                    ["value_template"] = "{{ value_json.state }}"
+                };
+
+                if (endpoint.GetStringSetting(OpenNettySettings.HomeAssistantDryContactDeviceClass) is string type)
+                {
+                    component["device_class"] = type;
+                }
+
+                if (endpoint.GetStringSetting(OpenNettySettings.HomeAssistantDryContactIcon) is string icon)
+                {
+                    component["icon"] = icon;
+                }
+
+                yield return component;
+
+                yield return new JsonObject
+                {
+                    ["platform"] = "button",
+                    ["unique_id"] = ComputeEntityUniqueId(endpoint, "00244687-d0b8-4839-a11c-7dcbda9f2f3b"u8),
+                    ["entity_category"] = "diagnostic",
+                    ["name"] = ComputeEntityDisplayName(
+                        name    : GetLocalizedString(SR.ID8128, culture),
+                        endpoint: endpoint,
+                        culture : culture,
+                        count   : endpoints.Count(static endpoint => endpoint.HasCapability(OpenNettyCapabilities.DryContactState))),
+                    ["availability_topic"] = $"{topic}/{OpenNettyMqttAttributes.Availability}",
+                    ["command_topic"] = $"{topic}/{OpenNettyMqttAttributes.DryContactState}/get",
+                    ["payload_press"] = string.Empty
+                };
+            }
+
             if (endpoint.HasCapability(OpenNettyCapabilities.OnOffScenarioActivation))
             {
                 yield return new JsonObject
@@ -1460,7 +1571,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
             }
 
             if (endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioActivation) &&
-                endpoint.GetStringSetting(OpenNettySettings.FunctionType) is OpenNettySettings.FunctionTypes.ScheduledScenario)
+                endpoint.GetStringSetting(OpenNettySettings.FunctionType) is null or OpenNettySettings.FunctionTypes.ScheduledScenario)
             {
                 if (endpoint.GetStringSetting(OpenNettySettings.PushButtonNumbers) is string value &&
                     value.Split([','], StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } values &&
@@ -1603,7 +1714,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
             }
 
             if (endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioPlusActivation) &&
-                endpoint.GetStringSetting(OpenNettySettings.FunctionType) is OpenNettySettings.FunctionTypes.ScheduledScenarioPlus)
+                endpoint.GetStringSetting(OpenNettySettings.FunctionType) is null or OpenNettySettings.FunctionTypes.ScheduledScenarioPlus)
             {
                 if (endpoint.GetStringSetting(OpenNettySettings.PushButtonNumbers) is string value &&
                     value.Split([','], StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } values &&
@@ -1798,7 +1909,6 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                     ["unique_id"] = ComputeEntityUniqueId(endpoint, "b7dd3824-ddc3-4cf3-b79e-168faa710e43"u8),
                     ["entity_category"] = "diagnostic",
                     ["device_class"] = "battery",
-                    ["off_delay"] = 3600,
                     ["name"] = ComputeEntityDisplayName(
                         name    : GetLocalizedString(SR.ID8029, culture),
                         endpoint: endpoint,
@@ -2573,7 +2683,7 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                         {% set map = {
                             'canceled': 'OFF',
                             'closed': 'OFF',
-                            'opened': 'ON'
+                            'open': 'ON'
                         } %}
                         {{ map[value] }}
                         """
@@ -2632,9 +2742,9 @@ public sealed class OpenNettyMqttWorker : IOpenNettyMqttWorker
                         {% set map = {
                             'closed': 'OFF',
                             'created': 'ON',
-                            'joint': 'OFF',
+                            'joined': 'OFF',
                             'left': 'OFF',
-                            'opened': 'ON'
+                            'open': 'ON'
                         } %}
                         {{ map[value] }}
                         """

--- a/src/OpenNetty/OpenNettyAddress.cs
+++ b/src/OpenNetty/OpenNettyAddress.cs
@@ -313,6 +313,22 @@ public readonly struct OpenNettyAddress : IEquatable<OpenNettyAddress>
         => FromNitooAddress(OpenNettyDeviceIdentifier.ToNitooSerialNumber(identifier), unit);
 
     /// <summary>
+    /// Creates a SCS dry contact address based on the specified parameters.
+    /// </summary>
+    /// <param name="identifier">The scenario identifier.</param>
+    /// <returns>A SCS dry contact address based on the specified parameters.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">One of the parameters is not valid.</exception>
+    public static OpenNettyAddress FromScsDryContactAddress(byte identifier)
+    {
+        if (identifier is > 201)
+        {
+            throw new ArgumentOutOfRangeException(nameof(identifier), SR.GetResourceString(SR.ID0132));
+        }
+
+        return new OpenNettyAddress(OpenNettyAddressType.ScsDryContact, $"3{identifier.ToString(CultureInfo.InvariantCulture)}");
+    }
+
+    /// <summary>
     /// Creates a SCS light point address based on the specified parameters.
     /// </summary>
     /// <param name="extension">The bus extension (also known as interface), or 0 to represent the private riser.</param>
@@ -525,6 +541,29 @@ public readonly struct OpenNettyAddress : IEquatable<OpenNettyAddress>
         }
 
         return (Identifier: value / 16, Unit: (byte) (value % 16));
+    }
+
+    /// <summary>
+    /// Converts the specified address to a SCS dry contact address.
+    /// </summary>
+    /// <param name="address">The address.</param>
+    /// <returns>A SCS dry contact address based on the specified address.</returns>
+    /// <exception cref="ArgumentException">The address doesn't represent a valid SCS dry contact address.</exception>
+    public static ushort ToScsDryContactAddress(OpenNettyAddress address)
+    {
+        if (address.Type is not OpenNettyAddressType.ScsDryContact)
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0133), nameof(address));
+        }
+
+        if (!address.Value.StartsWith('3') ||
+            !ushort.TryParse(address.Value.AsSpan()[1..], CultureInfo.InvariantCulture, out ushort identifier) ||
+            identifier is > 201)
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0134), nameof(address));
+        }
+
+        return identifier;
     }
 
     /// <summary>

--- a/src/OpenNetty/OpenNettyAddressType.cs
+++ b/src/OpenNetty/OpenNettyAddressType.cs
@@ -34,5 +34,10 @@ public enum OpenNettyAddressType
     /// <summary>
     /// SCS scenario plus address.
     /// </summary>
-    ScsScenarioPlus = 4
+    ScsScenarioPlus = 4,
+
+    /// <summary>
+    /// SCS dry contact address.
+    /// </summary>
+    ScsDryContact = 5
 }

--- a/src/OpenNetty/OpenNettyBuilder.cs
+++ b/src/OpenNetty/OpenNettyBuilder.cs
@@ -298,6 +298,7 @@ public sealed class OpenNettyBuilder
                 var type = (string?) endpoint.Attribute("Type") switch
                 {
                     "Nitoo"             => OpenNettyAddressType.Nitoo,
+                    "SCS dry contact"   => OpenNettyAddressType.ScsDryContact,
                     "SCS light point"   => OpenNettyAddressType.ScsLightPoint,
                     "SCS scenario plus" => OpenNettyAddressType.ScsScenarioPlus,
                     "Zigbee"            => OpenNettyAddressType.Zigbee,
@@ -328,9 +329,13 @@ public sealed class OpenNettyBuilder
 
                 var protocol = type switch
                 {
-                    OpenNettyAddressType.Nitoo                                                 => OpenNettyProtocol.Nitoo,
-                    OpenNettyAddressType.ScsLightPoint or OpenNettyAddressType.ScsScenarioPlus => OpenNettyProtocol.Scs,
-                    OpenNettyAddressType.Zigbee                                                => OpenNettyProtocol.Zigbee,
+                    OpenNettyAddressType.Nitoo => OpenNettyProtocol.Nitoo,
+
+                    OpenNettyAddressType.ScsDryContact or
+                    OpenNettyAddressType.ScsLightPoint or
+                    OpenNettyAddressType.ScsScenarioPlus => OpenNettyProtocol.Scs,
+
+                    OpenNettyAddressType.Zigbee => OpenNettyProtocol.Zigbee,
 
                     null => device?.Definition.Protocol ?? throw new InvalidOperationException(SR.FormatID0080(name, "Type")),
 
@@ -348,6 +353,9 @@ public sealed class OpenNettyBuilder
                         => OpenNettyAddress.FromNitooAddress(
                             identifier: identifier,
                             unit      : (byte?) (uint?) endpoint.Attribute("Unit") ?? unit?.Definition.Id ?? 0),
+
+                    OpenNettyAddressType.ScsDryContact when (byte?) (uint?) endpoint.Attribute("Id") is byte identifier
+                        => OpenNettyAddress.FromScsDryContactAddress(identifier),
 
                     OpenNettyAddressType.ScsLightPoint => OpenNettyAddress.FromScsLightPointAddress(
                         extension: (byte?) (uint?) endpoint.Attribute("Extension") ?? 0,

--- a/src/OpenNetty/OpenNettyCapabilities.cs
+++ b/src/OpenNetty/OpenNettyCapabilities.cs
@@ -72,6 +72,11 @@ public static class OpenNettyCapabilities
     public static readonly OpenNettyCapability BatteryLevel = new("Battery level");
 
     /// <summary>
+    /// Configurable function type.
+    /// </summary>
+    public static readonly OpenNettyCapability ConfigurableFunctionType = new("Configurable function type");
+
+    /// <summary>
     /// Configurable push button numbers.
     /// </summary>
     public static readonly OpenNettyCapability ConfigurablePushButtonNumbers = new("Configurable push button numbers");
@@ -95,6 +100,21 @@ public static class OpenNettyCapabilities
     /// Dimming scenario event.
     /// </summary>
     public static readonly OpenNettyCapability DimmingScenarioEvent = new("Dimming scenario event");
+
+    /// <summary>
+    /// Dry contact scenario activation.
+    /// </summary>
+    public static readonly OpenNettyCapability DryContactScenarioActivation = new("Dry contact scenario activation");
+
+    /// <summary>
+    /// Dry contact scenario event.
+    /// </summary>
+    public static readonly OpenNettyCapability DryContactScenarioEvent = new("Dry contact scenario event");
+
+    /// <summary>
+    /// Dry contact state.
+    /// </summary>
+    public static readonly OpenNettyCapability DryContactState = new("Dry contact state");
 
     /// <summary>
     /// Pressure scenario activation.

--- a/src/OpenNetty/OpenNettyCommands.cs
+++ b/src/OpenNetty/OpenNettyCommands.cs
@@ -284,6 +284,22 @@ public static class OpenNettyCommands
         public static readonly OpenNettyCommand EndOfExtendedPressure = new(OpenNettyCategories.ScenariosPlus, "24");
 
         /// <summary>
+        /// Dry contact ON (WHAT = 31).
+        /// </summary>
+        /// <remarks>
+        /// Note: this command requires specifying additional parameters.
+        /// </remarks>
+        public static readonly OpenNettyCommand DryContactOn = new(OpenNettyCategories.ScenariosPlus, "31");
+
+        /// <summary>
+        /// Dry contact OFF (WHAT = 32).
+        /// </summary>
+        /// <remarks>
+        /// Note: this command requires specifying additional parameters.
+        /// </remarks>
+        public static readonly OpenNettyCommand DryContactOff = new(OpenNettyCategories.ScenariosPlus, "32");
+
+        /// <summary>
         /// Binding request (WHAT = 33).
         /// </summary>
         public static readonly OpenNettyCommand BindingRequest = new(OpenNettyCategories.ScenariosPlus, "33");

--- a/src/OpenNetty/OpenNettyConfiguration.cs
+++ b/src/OpenNetty/OpenNettyConfiguration.cs
@@ -206,22 +206,16 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
 
             switch (endpoint.GetStringSetting(OpenNettySettings.FunctionType))
             {
-                // If the endpoint supports both lighting and automation commands,
-                // require that the function type be configured via the dedicated setting.
-                case null or { Length: 0 } when SupportsLightControl(endpoint) && SupportsShutterControl(endpoint):
+                // If the endpoint supports multiple conflicting types of operations (e.g light
+                // and shutter or pressure scenarios and pressure scenarios plus), require that
+                // the function type be configured via the dedicated setting.
+                case null or { Length: 0 } when endpoint.HasCapability(OpenNettyCapabilities.ConfigurableFunctionType):
                     builder.AddError(SR.FormatID2002(endpoint.Name));
-                    break;
-
-                // If the endpoint supports both pressure scenarios and pressure scenarios plus,
-                // require that the function type be configured via the dedicated setting.
-                case null or { Length: 0 } when
-                    endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioEvent) &&
-                    endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioPlusEvent):
-                    builder.AddError(SR.FormatID2014(endpoint.Name));
                     break;
 
                 case string value when value is not (
                     OpenNettySettings.FunctionTypes.AutomationActuator or
+                    OpenNettySettings.FunctionTypes.ContactState       or
                     OpenNettySettings.FunctionTypes.LightActuator      or 
                     OpenNettySettings.FunctionTypes.ScheduledScenario  or
                     OpenNettySettings.FunctionTypes.ScheduledScenarioPlus):
@@ -240,7 +234,12 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
 
             switch (endpoint.GetStringSetting(OpenNettySettings.PushButtonNumbers))
             {
-                case null or { Length: 0 } when endpoint.HasCapability(OpenNettyCapabilities.ConfigurablePushButtonNumbers):
+                // If the endpoint supports configurable push button numbers, require that the setting be configured.
+                case null or { Length: 0 } when
+                    endpoint.HasCapability(OpenNettyCapabilities.ConfigurablePushButtonNumbers) &&
+                    endpoint.GetStringSetting(OpenNettySettings.FunctionType) is null or
+                        OpenNettySettings.FunctionTypes.ScheduledScenario             or
+                        OpenNettySettings.FunctionTypes.ScheduledScenarioPlus:
                     builder.AddError(SR.FormatID2015(endpoint.Name));
                     break;
 
@@ -249,15 +248,6 @@ public sealed class OpenNettyConfiguration : IPostConfigureOptions<OpenNettyOpti
                     builder.AddError(SR.FormatID2016(endpoint.Name));
                     break;
             }
-
-            static bool SupportsLightControl(OpenNettyEndpoint endpoint) =>
-                endpoint.HasCapability(OpenNettyCapabilities.OnOffSwitchControl)  ||
-                endpoint.HasCapability(OpenNettyCapabilities.BasicDimmingControl) ||
-                endpoint.HasCapability(OpenNettyCapabilities.AdvancedDimmingControl);
-
-            static bool SupportsShutterControl(OpenNettyEndpoint endpoint) =>
-                endpoint.HasCapability(OpenNettyCapabilities.BasicShutterControl) ||
-                endpoint.HasCapability(OpenNettyCapabilities.AdvancedShutterControl);
         }
 
         return builder.Build();

--- a/src/OpenNetty/OpenNettyController.cs
+++ b/src/OpenNetty/OpenNettyController.cs
@@ -406,6 +406,45 @@ public class OpenNettyController
     }
 
     /// <summary>
+    /// Dispatches a virtual dry contact scenario for the specified endpoint.
+    /// </summary>
+    /// <param name="endpoint">The endpoint.</param>
+    /// <param name="type">The type of scenario to dispatch.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
+    public virtual ValueTask DispatchDryContactScenarioAsync(
+        OpenNettyEndpoint endpoint,
+        OpenNettyModels.ScenariosPlus.DryContactScenarioType type,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (!endpoint.HasCapability(OpenNettyCapabilities.DryContactScenarioActivation))
+        {
+            throw new InvalidOperationException(SR.GetResourceString(SR.ID0069));
+        }
+
+        return _service.ExecuteCommandAsync(
+            protocol         : endpoint.Protocol,
+            command          : type switch
+            {
+                OpenNettyModels.ScenariosPlus.DryContactScenarioType.Open
+                    => OpenNettyCommands.ScenariosPlus.DryContactOn.WithParameters("1"),
+
+                OpenNettyModels.ScenariosPlus.DryContactScenarioType.Closed
+                    => OpenNettyCommands.ScenariosPlus.DryContactOff.WithParameters("1"),
+
+                _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0068))
+            },
+            address          : endpoint.Address,
+            medium           : endpoint.Medium,
+            mode             : null,
+            gateway          : endpoint.Gateway,
+            options          : GetTransmissionOptions(endpoint),
+            cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
     /// Dispatches a virtual ON/OFF scenario for the specified endpoint.
     /// </summary>
     /// <param name="endpoint">The endpoint.</param>
@@ -1291,6 +1330,51 @@ public class OpenNettyController
     }
 
     /// <summary>
+    /// Resolves the current state of a dry contact endpoint.
+    /// </summary>
+    /// <param name="endpoint">The endpoint.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation
+    /// and whose result returns the current state of the specified dry contact endpoint.
+    /// </returns>
+    public virtual async ValueTask<OpenNettyModels.ScenariosPlus.DryContactState> GetDryContactStateAsync(
+        OpenNettyEndpoint endpoint,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        if (!endpoint.HasCapability(OpenNettyCapabilities.DryContactState))
+        {
+            throw new InvalidOperationException(SR.GetResourceString(SR.ID0069));
+        }
+
+        return await _service.GetStatusAsync(
+            protocol         : endpoint.Protocol,
+            category         : OpenNettyCategories.ScenariosPlus,
+            address          : endpoint.Address,
+            medium           : endpoint.Medium,
+            mode             : null,
+            // Note: CEN+ dry contact on/off commands used to determine the state of a dry contact are
+            // parameterized: in this case, only the commands originating from a state request are allowed.
+            filter           : static command => ValueTask.FromResult(
+                command == OpenNettyCommands.ScenariosPlus.DryContactOn.WithParameters("0") ||
+                command == OpenNettyCommands.ScenariosPlus.DryContactOff.WithParameters("0")),
+            gateway          : endpoint.Gateway,
+            options          : GetTransmissionOptions(endpoint),
+            cancellationToken: cancellationToken) switch
+        {
+            OpenNettyCommand command when command == OpenNettyCommands.ScenariosPlus.DryContactOn.WithParameters("0")
+                => OpenNettyModels.ScenariosPlus.DryContactState.Open,
+
+            OpenNettyCommand command when command == OpenNettyCommands.ScenariosPlus.DryContactOff.WithParameters("0")
+                => OpenNettyModels.ScenariosPlus.DryContactState.Closed,
+
+            _ => throw new InvalidDataException(SR.GetResourceString(SR.ID0068))
+        };
+    }
+
+    /// <summary>
     /// Resolves the firmware version of the specified endpoint.
     /// </summary>
     /// <param name="endpoint">The endpoint.</param>
@@ -1324,7 +1408,7 @@ public class OpenNettyController
         // is not aborted before the device has a chance to wake up and reply, the timeouts are
         // slightly increased but missing acknowledgment frames are explicitly ignored to ensure
         // the session will not be discarded by the worker if no acknowledgment frame is returned.
-        if (endpoint.Address is not null && endpoint.HasCapability(OpenNettyCapabilities.ZigbeeEndDevice))
+        if (endpoint.HasCapability(OpenNettyCapabilities.ZigbeeEndDevice))
         {
             options = options with
             {
@@ -1389,7 +1473,7 @@ public class OpenNettyController
         // is not aborted before the device has a chance to wake up and reply, the timeouts are
         // slightly increased but missing acknowledgment frames are explicitly ignored to ensure
         // the session will not be discarded by the worker if no acknowledgment frame is returned.
-        if (endpoint.Address is not null && endpoint.HasCapability(OpenNettyCapabilities.ZigbeeEndDevice))
+        if (endpoint.HasCapability(OpenNettyCapabilities.ZigbeeEndDevice))
         {
             options = options with
             {

--- a/src/OpenNetty/OpenNettyCoordinator.cs
+++ b/src/OpenNetty/OpenNettyCoordinator.cs
@@ -1228,7 +1228,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                         await _events.PublishAsync(new ZigbeeNetworkEventReportedEventArgs(endpoint,
                             command == OpenNettyCommands.Management.CreateZigbeeNetwork ? OpenNettyModels.Management.ZigbeeNetworkEventType.Created :
                             command == OpenNettyCommands.Management.CloseZigbeeNetwork  ? OpenNettyModels.Management.ZigbeeNetworkEventType.Closed  :
-                            command == OpenNettyCommands.Management.OpenZigbeeNetwork   ? OpenNettyModels.Management.ZigbeeNetworkEventType.Opened  :
+                            command == OpenNettyCommands.Management.OpenZigbeeNetwork   ? OpenNettyModels.Management.ZigbeeNetworkEventType.Open    :
                             command == OpenNettyCommands.Management.JoinZigbeeNetwork   ? OpenNettyModels.Management.ZigbeeNetworkEventType.Joined  :
                             command == OpenNettyCommands.Management.LeaveZigbeeNetwork  ? OpenNettyModels.Management.ZigbeeNetworkEventType.Left    :
                             throw new InvalidDataException(SR.GetResourceString(SR.ID0068))), cancellationToken);
@@ -1252,7 +1252,7 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                         if (endpoint.HasCapability(OpenNettyCapabilities.ZigbeeBinding))
                         {
                             await _events.PublishAsync(new ZigbeeBindingEventReportedEventArgs(endpoint,
-                                command == OpenNettyCommands.ScenariosPlus.OpenBinding   ? OpenNettyModels.ScenariosPlus.ZigbeeBindingEventType.Opened   :
+                                command == OpenNettyCommands.ScenariosPlus.OpenBinding   ? OpenNettyModels.ScenariosPlus.ZigbeeBindingEventType.Open     :
                                 command == OpenNettyCommands.ScenariosPlus.CloseBinding  ? OpenNettyModels.ScenariosPlus.ZigbeeBindingEventType.Closed   :
                                 command == OpenNettyCommands.ScenariosPlus.CancelBinding ? OpenNettyModels.ScenariosPlus.ZigbeeBindingEventType.Canceled :
                                 throw new InvalidDataException(SR.GetResourceString(SR.ID0068))), cancellationToken);
@@ -1362,6 +1362,41 @@ public sealed class OpenNettyCoordinator : IOpenNettyHandler
                         if (endpoint.HasCapability(OpenNettyCapabilities.PressureScenarioPlusEvent))
                         {
                             await _events.PublishAsync(new PressureScenarioPlusReportedEventArgs(endpoint, type, button), cancellationToken);
+                        }
+                    });
+                    break;
+                }
+
+                case (OpenNettyNotifications.MessageReceived,
+                      OpenNettyMessage { Protocol: OpenNettyProtocol.Scs,
+                                         Type    : OpenNettyMessageType.BusCommand,
+                                         Command : OpenNettyCommand command,
+                                         Address : not null })
+                    // Note: dry contact BUS COMMAND frames are parameterized.
+                    when command.WithParameters([]) == OpenNettyCommands.ScenariosPlus.DryContactOn ||
+                         command.WithParameters([]) == OpenNettyCommands.ScenariosPlus.DryContactOff:
+                {
+                    var endpoints = _manager.FindEndpointsByAddressAsync(notification.Gateway, message.Address.Value);
+
+                    await Parallel.ForEachAsync(endpoints, async (endpoint, cancellationToken) =>
+                    {
+                        if (endpoint.HasCapability(OpenNettyCapabilities.DryContactScenarioEvent))
+                        {
+                            await _events.PublishAsync(new DryContactScenarioReportedEventArgs(endpoint,
+                                command.WithParameters([]) == OpenNettyCommands.ScenariosPlus.DryContactOn  ? OpenNettyModels.ScenariosPlus.DryContactScenarioType.Open   :
+                                command.WithParameters([]) == OpenNettyCommands.ScenariosPlus.DryContactOff ? OpenNettyModels.ScenariosPlus.DryContactScenarioType.Closed :
+                                throw new InvalidDataException(SR.GetResourceString(SR.ID0068))), cancellationToken);
+                        }
+
+                        if (endpoint.HasCapability(OpenNettyCapabilities.DryContactState))
+                        {
+                            await _events.PublishAsync(new DryContactStateReportedEventArgs(endpoint,
+                                State : command.WithParameters([]) == OpenNettyCommands.ScenariosPlus.DryContactOn  ? OpenNettyModels.ScenariosPlus.DryContactState.Open   :
+                                        command.WithParameters([]) == OpenNettyCommands.ScenariosPlus.DryContactOff ? OpenNettyModels.ScenariosPlus.DryContactState.Closed :
+                                        throw new InvalidDataException(SR.GetResourceString(SR.ID0068)),
+                                Origin: command.Parameters is ["0"] ? OpenNettyModels.ScenariosPlus.DryContactStateOrigin.StateRequest :
+                                        command.Parameters is ["1"] ? OpenNettyModels.ScenariosPlus.DryContactStateOrigin.SystemEvent  :
+                                        throw new InvalidDataException(SR.GetResourceString(SR.ID0068))), cancellationToken);
                         }
                     });
                     break;

--- a/src/OpenNetty/OpenNettyDevices.xml
+++ b/src/OpenNetty/OpenNettyDevices.xml
@@ -1022,6 +1022,7 @@
     <Unit Id="1">
       <Capability Name="Basic shutter control" />
       <Capability Name="Basic shutter state" />
+      <Capability Name="Configurable function type" />
       <Capability Name="On/off switch state" />
       <Capability Name="On/off switch control" />
 
@@ -1052,6 +1053,7 @@
     <Unit Id="1">
       <Capability Name="Basic shutter control" />
       <Capability Name="Basic shutter state" />
+      <Capability Name="Configurable function type" />
       <Capability Name="On/off switch state" />
       <Capability Name="On/off switch control" />
 
@@ -1070,6 +1072,7 @@
     <Unit Id="3">
       <Capability Name="Basic shutter control" />
       <Capability Name="Basic shutter state" />
+      <Capability Name="Configurable function type" />
       <Capability Name="On/off switch state" />
       <Capability Name="On/off switch control" />
 
@@ -1134,21 +1137,29 @@
     </Identity>
 
     <Unit Id="1">
+      <Capability Name="Configurable function type" />
       <Capability Name="Configurable push button numbers" />
+      <Capability Name="Dry contact scenario activation" />
+      <Capability Name="Dry contact scenario event" />
+      <Capability Name="Dry contact state" />
       <Capability Name="Pressure scenario activation" />
       <Capability Name="Pressure scenario event" />
       <Capability Name="Pressure scenario plus activation" />
       <Capability Name="Pressure scenario plus event" />
 
-      <Description Culture="en" Value="Input 2" />
-      <Description Culture="fr" Value="Entrée 2" />
+      <Description Culture="en" Value="Input 1" />
+      <Description Culture="fr" Value="Entrée 1" />
 
       <Setting Name="Home Assistant scenario device class" Value="button" />
       <Setting Name="Home Assistant scenario icon" Value="mdi:gesture-tap-button" />
     </Unit>
 
     <Unit Id="2">
+      <Capability Name="Configurable function type" />
       <Capability Name="Configurable push button numbers" />
+      <Capability Name="Dry contact scenario activation" />
+      <Capability Name="Dry contact scenario event" />
+      <Capability Name="Dry contact state" />
       <Capability Name="Pressure scenario activation" />
       <Capability Name="Pressure scenario event" />
       <Capability Name="Pressure scenario plus activation" />
@@ -1245,6 +1256,7 @@
     </Unit>
 
     <Unit Id="3">
+      <Capability Name="Configurable function type" />
       <Capability Name="Configurable push button numbers" />
       <Capability Name="Pressure scenario activation" />
       <Capability Name="Pressure scenario event" />
@@ -1259,6 +1271,7 @@
     </Unit>
 
     <Unit Id="4">
+      <Capability Name="Configurable function type" />
       <Capability Name="Configurable push button numbers" />
       <Capability Name="Pressure scenario activation" />
       <Capability Name="Pressure scenario event" />

--- a/src/OpenNetty/OpenNettyEvents.cs
+++ b/src/OpenNetty/OpenNettyEvents.cs
@@ -113,6 +113,18 @@ public sealed class OpenNettyEvents : IDisposable
         => _observable.OfType<EventArgs, DimmingScenarioReportedEventArgs>();
 
     /// <summary>
+    /// Gets an event triggered when a dry contact scenario is reported.
+    /// </summary>
+    public IAsyncObservable<DryContactScenarioReportedEventArgs> DryContactScenarioReported
+        => _observable.OfType<EventArgs, DryContactScenarioReportedEventArgs>();
+
+    /// <summary>
+    /// Gets an event triggered when a dry contact state is reported.
+    /// </summary>
+    public IAsyncObservable<DryContactStateReportedEventArgs> DryContactStateReported
+        => _observable.OfType<EventArgs, DryContactStateReportedEventArgs>();
+
+    /// <summary>
     /// Gets an event triggered when an incoming message is reported.
     /// </summary>
     public IAsyncObservable<IncomingMessageReportedEventArgs> IncomingMessageReported
@@ -325,6 +337,24 @@ public sealed class OpenNettyEvents : IDisposable
     /// <param name="Endpoint">The endpoint.</param>
     /// <param name="Step">The dimming step (positive or negative).</param>
     public sealed record class DimmingScenarioReportedEventArgs(OpenNettyEndpoint Endpoint, short Step) : EventArgs(Endpoint);
+
+    /// <summary>
+    /// Represents event arguments used when a dry contact scenario is reported.
+    /// </summary>
+    /// <param name="Endpoint">The endpoint.</param>
+    /// <param name="Type">The dry contact scenario type.</param>
+    public sealed record class DryContactScenarioReportedEventArgs(OpenNettyEndpoint Endpoint,
+        OpenNettyModels.ScenariosPlus.DryContactScenarioType Type) : EventArgs(Endpoint);
+
+    /// <summary>
+    /// Represents event arguments used when a dry contact state is reported.
+    /// </summary>
+    /// <param name="Endpoint">The endpoint.</param>
+    /// <param name="State">The state of the dry contact.</param>
+    /// <param name="Origin">The origin of the dry contact state report.</param>
+    public sealed record class DryContactStateReportedEventArgs(OpenNettyEndpoint Endpoint,
+        OpenNettyModels.ScenariosPlus.DryContactState State,
+        OpenNettyModels.ScenariosPlus.DryContactStateOrigin Origin) : EventArgs(Endpoint);
 
     /// <summary>
     /// Represents event arguments used when an incoming message is reported.

--- a/src/OpenNetty/OpenNettyManager.cs
+++ b/src/OpenNetty/OpenNettyManager.cs
@@ -180,6 +180,19 @@ public class OpenNettyManager
             }
         }
 
+        else if (address.Type is OpenNettyAddressType.ScsDryContact or OpenNettyAddressType.ScsScenarioPlus)
+        {
+            await foreach (var endpoint in EnumerateEndpointsAsync(cancellationToken))
+            {
+                if (endpoint.Protocol is OpenNettyProtocol.Scs &&
+                    endpoint.Gateway == gateway &&
+                    endpoint.Address is not null && endpoint.Address == address)
+                {
+                    yield return endpoint;
+                }
+            }
+        }
+
         else if (address.Type is OpenNettyAddressType.ScsLightPoint)
         {
             var (extension, general, group, area, point) = OpenNettyAddress.ToScsLightPointAddress(address);
@@ -219,19 +232,6 @@ public class OpenNettyManager
                     {
                         yield return endpoint;
                     }
-                }
-            }
-        }
-
-        else if (address.Type is OpenNettyAddressType.ScsScenarioPlus)
-        {
-            await foreach (var endpoint in EnumerateEndpointsAsync(cancellationToken))
-            {
-                if (endpoint.Protocol is OpenNettyProtocol.Scs &&
-                    endpoint.Gateway == gateway &&
-                    endpoint.Address is not null && endpoint.Address == address)
-                {
-                    yield return endpoint;
                 }
             }
         }

--- a/src/OpenNetty/OpenNettyMessage.cs
+++ b/src/OpenNetty/OpenNettyMessage.cs
@@ -123,9 +123,9 @@ public sealed class OpenNettyMessage : IEquatable<OpenNettyMessage>
                 [
                     { Parameters: [{ IsEmpty: true }, { IsEmpty: true }] },
                     { Parameters: [{           Value: "6"             }] }
-                ] => protocol is OpenNettyProtocol.Zigbee ?
-                    OpenNettyMessageType.BusyNegativeAcknowledgement :
-                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0058)),
+                ] => protocol is OpenNettyProtocol.Zigbee
+                    ? OpenNettyMessageType.BusyNegativeAcknowledgement
+                    : throw new InvalidOperationException(SR.GetResourceString(SR.ID0058)),
 
                 // Status request messages MUST have exactly 2 fields:
                 //
@@ -208,9 +208,9 @@ public sealed class OpenNettyMessage : IEquatable<OpenNettyMessage>
                 parameters.Add(frame.Fields[0].Parameters[index].Value);
             }
 
-            message.Category = new OpenNettyCategory(message.Type is OpenNettyMessageType.BusCommand ?
-                frame.Fields[0].Parameters[0].Value :
-                frame.Fields[0].Parameters[1].Value, [.. parameters]);
+            message.Category = new OpenNettyCategory(message.Type is OpenNettyMessageType.BusCommand
+                ? frame.Fields[0].Parameters[0].Value
+                : frame.Fields[0].Parameters[1].Value, [.. parameters]);
         }
 
         // Then, infer the command/status from the WHAT field if the message is a command.
@@ -254,13 +254,7 @@ public sealed class OpenNettyMessage : IEquatable<OpenNettyMessage>
                 {
                     message.Medium = OpenNettyMedium.Bus;
 
-                    var type =
-                        // Note: the WHO=2 and WHO=15 categories use the same addressing scheme as the WHO=1 category.
-                        message.Category == OpenNettyCategories.Lighting      ? OpenNettyAddressType.ScsLightPoint   :
-                        message.Category == OpenNettyCategories.Automation    ? OpenNettyAddressType.ScsLightPoint   :
-                        message.Category == OpenNettyCategories.Scenarios     ? OpenNettyAddressType.ScsLightPoint   :
-                        message.Category == OpenNettyCategories.ScenariosPlus ? OpenNettyAddressType.ScsScenarioPlus :
-                                                                                OpenNettyAddressType.Unknown;
+                    var type = GetAddressType(message.Category, field);
 
                     if (field.Parameters.Length is 1)
                     {
@@ -278,6 +272,37 @@ public sealed class OpenNettyMessage : IEquatable<OpenNettyMessage>
 
                         message.Address = new OpenNettyAddress(type, field.Parameters[0].Value, [.. parameters]);
                     }
+                }
+
+                static OpenNettyAddressType GetAddressType(OpenNettyCategory? category, OpenNettyField field)
+                {
+                    // Note: the WHO=2 and WHO=15 categories use the same addressing scheme as the WHO=1 category.
+                    if (category == OpenNettyCategories.Lighting   ||
+                        category == OpenNettyCategories.Automation ||
+                        category == OpenNettyCategories.Scenarios)
+                    {
+                        return OpenNettyAddressType.ScsLightPoint;
+                    }
+
+                    // Note: the WHO=25 category uses different types of addresses, always
+                    // prefixed by a discriminator character (2 for CEN+, 3 for DRY CONTACT).
+                    if (category == OpenNettyCategories.ScenariosPlus)
+                    {
+                        if (field.Parameters is not [{ Value: [char discriminator, ..] }])
+                        {
+                            return OpenNettyAddressType.Unknown;
+                        }
+
+                        return discriminator switch
+                        {
+                            '2' => OpenNettyAddressType.ScsScenarioPlus,
+                            '3' => OpenNettyAddressType.ScsDryContact,
+
+                            _ => OpenNettyAddressType.Unknown
+                        };
+                    }
+
+                    return OpenNettyAddressType.Unknown;
                 }
             }
 
@@ -674,6 +699,7 @@ public sealed class OpenNettyMessage : IEquatable<OpenNettyMessage>
                 ["type"] = address.Type switch
                 {
                     OpenNettyAddressType.Nitoo           => "nitoo",
+                    OpenNettyAddressType.ScsDryContact   => "scs_dry_contact",
                     OpenNettyAddressType.ScsLightPoint   => "scs_light_point",
                     OpenNettyAddressType.ScsScenarioPlus => "scs_scenario_plus",
                     OpenNettyAddressType.Zigbee          => "zigbee",
@@ -692,6 +718,10 @@ public sealed class OpenNettyMessage : IEquatable<OpenNettyMessage>
                     is { Identifier: var identifier, Unit: var unit }:
                     result["address"]?["identifier"] = identifier;
                     result["address"]?["unit"] = unit;
+                    break;
+
+                case OpenNettyAddressType.ScsDryContact:
+                    result["address"]?["contact"] = OpenNettyAddress.ToScsDryContactAddress(address);
                     break;
 
                 case OpenNettyAddressType.ScsLightPoint when OpenNettyAddress.ToScsLightPointAddress(address)
@@ -836,6 +866,9 @@ public sealed class OpenNettyMessage : IEquatable<OpenNettyMessage>
                               (byte?) node["unit"]?.AsValue()       is var unit
                     => OpenNettyAddress.FromDecimalZigbeeAddress(identifier, unit ?? 0),
 
+                "scs_dry_contact" when (byte?) node["contact"]?.AsValue() is byte identifier
+                    => OpenNettyAddress.FromScsDryContactAddress(identifier),
+
                 "scs_light_point" when (byte?) node["extension"]?.AsValue() is var extension &&
                                        (bool?) node["general"]?.AsValue()   is var general &&
                                        (byte?) node["group"]?.AsValue()     is var group &&
@@ -978,7 +1011,8 @@ public sealed class OpenNettyMessage : IEquatable<OpenNettyMessage>
                                                             category == OpenNettyCategories.Scenarios
                     => throw new InvalidOperationException(SR.GetResourceString(SR.ID0050)),
 
-                not OpenNettyAddressType.ScsScenarioPlus when category == OpenNettyCategories.ScenariosPlus
+                not (OpenNettyAddressType.ScsDryContact or OpenNettyAddressType.ScsScenarioPlus)
+                    when category == OpenNettyCategories.ScenariosPlus
                     => throw new InvalidOperationException(SR.GetResourceString(SR.ID0114)),
 
                 _ => new OpenNettyField(address.Value.ToParameters()),

--- a/src/OpenNetty/OpenNettyModels.cs
+++ b/src/OpenNetty/OpenNettyModels.cs
@@ -565,9 +565,9 @@ public static class OpenNettyModels
             Closed = 0,
 
             /// <summary>
-            /// Opened.
+            /// Open.
             /// </summary>
-            Opened = 1,
+            Open = 1,
 
             /// <summary>
             /// Created.
@@ -640,6 +640,54 @@ public static class OpenNettyModels
         }
 
         /// <summary>
+        /// Dry contact scenario type.
+        /// </summary>
+        public enum DryContactScenarioType
+        {
+            /// <summary>
+            /// Closed.
+            /// </summary>
+            Closed = 0,
+
+            /// <summary>
+            /// Open.
+            /// </summary>
+            Open = 1
+        }
+
+        /// <summary>
+        /// Dry contact state.
+        /// </summary>
+        public enum DryContactState
+        {
+            /// <summary>
+            /// Closed.
+            /// </summary>
+            Closed = 0,
+
+            /// <summary>
+            /// Open.
+            /// </summary>
+            Open = 1
+        }
+
+        /// <summary>
+        /// Dry contact state origin.
+        /// </summary>
+        public enum DryContactStateOrigin
+        {
+            /// <summary>
+            /// State request.
+            /// </summary>
+            StateRequest = 0,
+
+            /// <summary>
+            /// System event.
+            /// </summary>
+            SystemEvent = 1
+        }
+
+        /// <summary>
         /// Pressure scenario type.
         /// </summary>
         public enum PressureScenarioType
@@ -676,9 +724,9 @@ public static class OpenNettyModels
             Closed = 0,
 
             /// <summary>
-            /// Opened.
+            /// Open.
             /// </summary>
-            Opened = 1,
+            Open = 1,
 
             /// <summary>
             /// Canceled.

--- a/src/OpenNetty/OpenNettyResources.fr.resx
+++ b/src/OpenNetty/OpenNettyResources.fr.resx
@@ -486,4 +486,16 @@
   <data name="ID8124" xml:space="preserve">
     <value>Point de terminaison virtuel SCS scénario plus</value>
   </data>
+  <data name="ID8125" xml:space="preserve">
+    <value>Activer scénario contact sec ouvert/détection</value>
+  </data>
+  <data name="ID8126" xml:space="preserve">
+    <value>Activer scénario contact sec fermé/fin de détection</value>
+  </data>
+  <data name="ID8127" xml:space="preserve">
+    <value>Contact sec/détection</value>
+  </data>
+  <data name="ID8128" xml:space="preserve">
+    <value>Récupérer état contact sec/détection</value>
+  </data>
 </root>

--- a/src/OpenNetty/OpenNettyResources.resx
+++ b/src/OpenNetty/OpenNettyResources.resx
@@ -510,6 +510,15 @@
   <data name="ID0131" xml:space="preserve">
     <value>The requested operation requires firmware version {0} or later. Current version for gateway '{1}': {2}.</value>
   </data>
+  <data name="ID0132" xml:space="preserve">
+    <value>The dry contact identifier must be between 0 and 201.</value>
+  </data>
+  <data name="ID0133" xml:space="preserve">
+    <value>The address doesn't represent a SCS CEN+ address.</value>
+  </data>
+  <data name="ID0134" xml:space="preserve">
+    <value>The address doesn't represent a valid SCS CEN+ address.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The endpoint name '{0}' is not valid. Endpoint names cannot contain the '+' or '*' characters.</value>
   </data>
@@ -517,10 +526,10 @@
     <value>The MQTT root topic cannot contain the '+' or '*' characters.</value>
   </data>
   <data name="ID2002" xml:space="preserve">
-    <value>The endpoint '{0}' doesn't have a function type setting attached. Endpoints that support both light and shutter operations must be attached an function type setting reflecting the type configured via MyHome Suite.</value>
+    <value>The endpoint '{0}' doesn't have a function type setting attached. Endpoints that support multiple types of operations (e.g light and shutter or pressure scenarios and pressure scenarios plus) must be attached a function type setting reflecting the type configured via MyHome Suite.</value>
   </data>
   <data name="ID2003" xml:space="preserve">
-    <value>The endpoint '{0}' doesn't have a valid function type setting attached ({1}). Only 'Light actuator', 'Automation actuator', 'Scheduled scenario' and 'Scheduled scenario plus' are currently supported.</value>
+    <value>The endpoint '{0}' doesn't have a valid function type setting attached ({1}). Only 'Light actuator', 'Automation actuator', 'Contact state', 'Scheduled scenario' and 'Scheduled scenario plus' are currently supported.</value>
   </data>
   <data name="ID2004" xml:space="preserve">
     <value>The endpoint '{0}' doesn't have a valid switch mode setting attached ({1}). Only 'Default' and 'Push button' are currently supported.</value>
@@ -551,9 +560,6 @@
   </data>
   <data name="ID2013" xml:space="preserve">
     <value>Multiple endpoints with the name '{0}' have been added.</value>
-  </data>
-  <data name="ID2014" xml:space="preserve">
-    <value>The endpoint '{0}' doesn't have a function type setting attached. Endpoints that support both pressure scenarios and pressure scenarios plus must be attached an function type setting reflecting the type configured via MyHome Suite.</value>
   </data>
   <data name="ID2015" xml:space="preserve">
     <value>The endpoint '{0}' supports configurable push button numbers but doesn't have a list of numbers attached. Make sure the list of push button numbers configured in MyHome Suite is attached as an endpoint setting.</value>
@@ -1016,5 +1022,17 @@
   </data>
   <data name="ID8124" xml:space="preserve">
     <value>Virtual SCS scenario plus endpoint</value>
+  </data>
+  <data name="ID8125" xml:space="preserve">
+    <value>Dispatch dry contact open/detection scenario</value>
+  </data>
+  <data name="ID8126" xml:space="preserve">
+    <value>Dispatch dry contact closed/end of detection scenario</value>
+  </data>
+  <data name="ID8127" xml:space="preserve">
+    <value>Dry contact/detection</value>
+  </data>
+  <data name="ID8128" xml:space="preserve">
+    <value>Get dry contact/detection state</value>
   </data>
 </root>

--- a/src/OpenNetty/OpenNettySettings.cs
+++ b/src/OpenNetty/OpenNettySettings.cs
@@ -57,6 +57,16 @@ public static class OpenNettySettings
     public static readonly OpenNettySetting HomeAssistantDiscoveryUICulture = new("Home Assistant discovery UI culture");
 
     /// <summary>
+    /// Home Assistant dry contact device class.
+    /// </summary>
+    public static readonly OpenNettySetting HomeAssistantDryContactDeviceClass = new("Home Assistant dry contact device class");
+
+    /// <summary>
+    /// Home Assistant dry contact icon.
+    /// </summary>
+    public static readonly OpenNettySetting HomeAssistantDryContactIcon = new("Home Assistant dry contact icon");
+
+    /// <summary>
     /// Home Assistant entity type.
     /// </summary>
     public static readonly OpenNettySetting HomeAssistantEntityType = new("Home Assistant entity type");
@@ -210,6 +220,11 @@ public static class OpenNettySettings
         /// Automation actuator.
         /// </summary>
         public const string AutomationActuator = "Automation actuator";
+
+        /// <summary>
+        /// Contact state.
+        /// </summary>
+        public const string ContactState = "Contact state";
 
         /// <summary>
         /// Light actuator.


### PR DESCRIPTION
This PR adds full support for MyHome dry contact endpoints, including the ability to dispatch virtual dry contact scenarios/state changes.